### PR TITLE
feat: JWT 리프레시 토큰 메커니즘 구현

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
@@ -4,14 +4,14 @@ import com.onedrinktoday.backend.domain.member.dto.MemberRequest;
 import com.onedrinktoday.backend.domain.member.dto.MemberResponse;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
 import jakarta.validation.Valid;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.onedrinktoday.backend.global.security.TokenDTO;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,19 +27,16 @@ public class MemberController {
   }
 
   @PostMapping("/members/signin")
-  public ResponseEntity<String> signIn(@Valid @RequestBody MemberRequest.SignIn request) {
+  public ResponseEntity<TokenDTO> signIn(@Valid @RequestBody MemberRequest.SignIn request) {
 
     return ResponseEntity.ok(memberService.signIn(request));
   }
 
   @PostMapping("/members/refresh")
-  public ResponseEntity<Map<String, String>> refreshAccessToken(@RequestBody String refreshToken) {
+  public ResponseEntity<TokenDTO> refreshAccessToken(
+      @RequestHeader("Refresh-Token") String refreshToken) {
 
-    Map<String, String> response = new HashMap<>();
-    response.put("accessToken", memberService.refreshAccessToken(refreshToken));
-
-    return ResponseEntity.ok(response);
+    return ResponseEntity.ok(memberService.refreshAccessToken(refreshToken));
   }
-
 
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
@@ -4,6 +4,8 @@ import com.onedrinktoday.backend.domain.member.dto.MemberRequest;
 import com.onedrinktoday.backend.domain.member.dto.MemberResponse;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
 import jakarta.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,7 +32,14 @@ public class MemberController {
     return ResponseEntity.ok(memberService.signIn(request));
   }
 
+  @PostMapping("/members/refresh")
+  public ResponseEntity<Map<String, String>> refreshAccessToken(@RequestBody String refreshToken) {
 
+    Map<String, String> response = new HashMap<>();
+    response.put("accessToken", memberService.refreshAccessToken(refreshToken));
+
+    return ResponseEntity.ok(response);
+  }
 
 
 }

--- a/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
@@ -12,7 +12,9 @@ public enum ErrorCode {
   EMAIL_EXIST("이미 가입된 메일입니다.", HttpStatus.BAD_REQUEST),
   REGION_NOT_FOUND("지역을 찾을수 없습니다.", HttpStatus.BAD_REQUEST),
   REGION_EXIST("이미 존재하는 지역명입니다.", HttpStatus.BAD_REQUEST),
-  LOGIN_FAIL("이메일, 비밀번호를 확인해 주세요.", HttpStatus.BAD_REQUEST);
+  LOGIN_FAIL("이메일, 비밀번호를 확인해 주세요.", HttpStatus.BAD_REQUEST),
+  TOKEN_EXPIRED("토큰이 유효 기간이 지나서 만료되었습니다.", HttpStatus.BAD_REQUEST),
+  INVALID_REFRESH_TOKEN("리프레시 토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST);
 
   private final String message;
   private final HttpStatus status;

--- a/src/main/java/com/onedrinktoday/backend/global/security/JwtProvider.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/JwtProvider.java
@@ -19,6 +19,7 @@ public class JwtProvider {
 
   private final SecretKey secretKey;
   private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 30;
+  private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 7;
 
   public JwtProvider(@Value("${spring.jwt.secret}") String secret) {
     this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
@@ -31,6 +32,16 @@ public class JwtProvider {
         .claim("role", role)
         .issuedAt(new Date())
         .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
+        .signWith(secretKey)
+        .compact();
+  }
+
+  public String createRefreshToken(String email, Role role) {
+    return Jwts.builder()
+        .subject(email)
+        .claim("role", role)
+        .issuedAt(new Date())
+        .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME))
         .signWith(secretKey)
         .compact();
   }

--- a/src/main/java/com/onedrinktoday/backend/global/security/JwtProvider.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/JwtProvider.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 public class JwtProvider {
 
   private final SecretKey secretKey;
-  private static final long EXPIRE_TIME = 1000 * 60 * 60 * 24;
+  private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 30;
 
   public JwtProvider(@Value("${spring.jwt.secret}") String secret) {
     this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
@@ -30,7 +30,7 @@ public class JwtProvider {
         .subject(email)
         .claim("role", role)
         .issuedAt(new Date())
-        .expiration(new Date(System.currentTimeMillis() + EXPIRE_TIME))
+        .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
         .signWith(secretKey)
         .compact();
   }

--- a/src/main/java/com/onedrinktoday/backend/global/security/JwtProvider.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/JwtProvider.java
@@ -1,6 +1,7 @@
 package com.onedrinktoday.backend.global.security;
 
 import com.onedrinktoday.backend.global.type.Role;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -33,5 +34,21 @@ public class JwtProvider {
   public String getEmail(String token) {
     return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token)
         .getPayload().getSubject();
+  }
+
+  public boolean isTokenExpired(String refreshToken) {
+    try {
+      Claims claims = Jwts.parser()
+          .verifyWith(secretKey)
+          .build()
+          .parseSignedClaims(refreshToken)
+          .getPayload();
+
+      Date expiration = claims.getExpiration();
+
+      return expiration.before(new Date());
+    } catch (RuntimeException e) {
+      return true;
+    }
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/global/security/JwtProvider.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/JwtProvider.java
@@ -2,7 +2,11 @@ package com.onedrinktoday.backend.global.security;
 
 import com.onedrinktoday.backend.global.type.Role;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import javax.crypto.SecretKey;
@@ -47,7 +51,8 @@ public class JwtProvider {
       Date expiration = claims.getExpiration();
 
       return expiration.before(new Date());
-    } catch (RuntimeException e) {
+    } catch (SignatureException | UnsupportedJwtException | ExpiredJwtException |
+             MalformedJwtException e) {
       return true;
     }
   }

--- a/src/main/java/com/onedrinktoday/backend/global/security/TokenDTO.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/TokenDTO.java
@@ -1,0 +1,12 @@
+package com.onedrinktoday.backend.global.security;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenDTO {
+
+  private String accessToken;
+  private String refreshToken;
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
* domain 패키지:
  * 엑세스 토큰 만료 시 리프레시 토큰을 통해 새로운 엑세스 토큰을 발급받는 기능을 구현

* global 패키지
  * ErrorCode파일에서 JWT를 사용하는 인증 시스템에 관한 토큰 관련 문제 에러 코드 생성
---

- 응답 형식을 문자열 대신 JSON 형태의 Map으로 구성하여 사용자에게 제공하도록 하였습니다.

---
**TO-BE**
- 액세스 토큰 갱신 가능

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 