### PR TITLE
feat: 구글 로그인 기능 구현

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/onedrinktoday/backend/global/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.onedrinktoday.backend.global.config;
 
+import com.onedrinktoday.backend.global.security.JwtFilter;
+import com.onedrinktoday.backend.global.security.JwtProvider;
+import com.onedrinktoday.backend.global.security.MemberDetailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,6 +12,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
@@ -17,17 +21,26 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+  private final JwtProvider jwtProvider;
+  private final MemberDetailService memberDetailService;
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
     http
         .authorizeHttpRequests((auth) -> auth
             .requestMatchers(AntPathRequestMatcher.antMatcher("/**")).permitAll()
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/api/regions/**")).permitAll()
+            .anyRequest().authenticated()
         );
 
     http //폼 로그인, csrf disable
         .formLogin(AbstractHttpConfigurer::disable)
         .csrf(AbstractHttpConfigurer::disable);
+
+    http //JWT 토큰 확인 필터를 UsernamePasswordAuthenticationFilter 보다 앞에 위치
+        .addFilterBefore(new JwtFilter(jwtProvider, memberDetailService),
+            UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
   }

--- a/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
   CONVERT_ERROR("변환 에러", HttpStatus.BAD_REQUEST),
   EMAIL_EXIST("이미 가입된 메일입니다.", HttpStatus.BAD_REQUEST),
+  EMAIL_NOT_FOUND("이메일이 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
   REGION_NOT_FOUND("지역을 찾을수 없습니다.", HttpStatus.BAD_REQUEST),
   REGION_EXIST("이미 존재하는 지역명입니다.", HttpStatus.BAD_REQUEST),
   LOGIN_FAIL("이메일, 비밀번호를 확인해 주세요.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/onedrinktoday/backend/global/security/GoogleController.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/GoogleController.java
@@ -1,0 +1,31 @@
+package com.onedrinktoday.backend.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api")
+@RequiredArgsConstructor
+public class GoogleController {
+
+  @Value("${oauth2.google.login-uri}")
+  private String loginUri;
+
+  private final GoogleService googleService;
+
+  @PostMapping("/google/join")
+  public ResponseEntity<String> join(@RequestParam String code) {
+    return ResponseEntity.ok(googleService.join(code));
+  }
+
+  @GetMapping("/google/login-uri")
+  public ResponseEntity<String> getLoginUri() {
+    return ResponseEntity.ok(loginUri);
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/global/security/GoogleService.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/GoogleService.java
@@ -1,0 +1,89 @@
+package com.onedrinktoday.backend.global.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
+import com.onedrinktoday.backend.global.type.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleService {
+
+  private final RestTemplate restTemplate = new RestTemplate();
+  private final MemberRepository memberRepository;
+  private final JwtProvider jwtProvider;
+
+  @Value("${oauth2.google.client-id}")
+  private String clientId;
+
+  @Value("${oauth2.google.client-secret}")
+  private String clientSecret;
+
+  @Value("${oauth2.google.redirect-uri}")
+  private String redirectUri;
+
+  @Value("${oauth2.google.token-uri}")
+  private String tokenUri;
+
+  @Value("${oauth2.google.resource-uri}")
+  private String resourceUri;
+
+  public String join(String code) {
+    String accessToken = getAccessToken(code);
+    JsonNode userResourceNode = getUserResource(accessToken);
+
+    String id = userResourceNode.get("id").asText();
+    String email = userResourceNode.get("email").asText();
+    String name = userResourceNode.get("name").asText();
+
+    Member member = memberRepository.findByEmail(email)
+        .orElse(memberRepository.save(Member.builder()
+            .name(name)
+            .email(email)
+            .password(id)
+            .role(Role.USER)
+            .alarmEnabled(true)
+            .build())
+        );
+
+    return jwtProvider.createToken(member.getEmail(), member.getRole());
+  }
+
+  private String getAccessToken(String code) {
+
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("code", code);
+    params.add("client_id", clientId);
+    params.add("client_secret", clientSecret);
+    params.add("redirect_uri", redirectUri);
+    params.add("grant_type", "authorization_code");
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    HttpEntity entity = new HttpEntity(params, headers);
+
+    JsonNode accessTokenNode =
+        restTemplate.exchange(tokenUri, HttpMethod.POST, entity, JsonNode.class).getBody();
+
+    return accessTokenNode.get("access_token").asText();
+  }
+
+  private JsonNode getUserResource(String accessToken) {
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "Bearer " + accessToken);
+    HttpEntity entity = new HttpEntity(headers);
+    return restTemplate.exchange(resourceUri, HttpMethod.GET, entity, JsonNode.class).getBody();
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/global/security/JwtFilter.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/JwtFilter.java
@@ -1,0 +1,42 @@
+package com.onedrinktoday.backend.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+  private final JwtProvider jwtProvider;
+  private final MemberDetailService memberDetailService;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String token = request.getHeader("TOKEN");
+
+    if (token != null && jwtProvider.getEmail(token) != null) {
+
+      String email = jwtProvider.getEmail(token);
+      MemberDetail userDetails = memberDetailService.loadUserByUsername(email);
+
+      Authentication auth =
+          new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+      SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/global/security/MemberDetail.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/MemberDetail.java
@@ -1,0 +1,30 @@
+package com.onedrinktoday.backend.global.security;
+
+import com.onedrinktoday.backend.domain.member.dto.MemberResponse;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import java.util.Collection;
+import java.util.List;
+import lombok.Data;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Data
+public class MemberDetail implements UserDetails {
+
+  private final MemberResponse member;
+
+  @Override
+  public String getUsername() {
+    return member.getEmail();
+  }
+
+  @Override
+  public String getPassword() {
+    return null;
+  }
+
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of(new SimpleGrantedAuthority(member.getRole().toString()));
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/global/security/MemberDetailService.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/MemberDetailService.java
@@ -1,0 +1,27 @@
+package com.onedrinktoday.backend.global.security;
+
+
+import com.onedrinktoday.backend.domain.member.dto.MemberResponse;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
+import com.onedrinktoday.backend.global.exception.CustomException;
+import com.onedrinktoday.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDetailService implements UserDetailsService {
+
+  private final MemberRepository memberRepository;
+
+  @Override
+  public MemberDetail loadUserByUsername(String email) {
+
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new CustomException(ErrorCode.EMAIL_EXIST));
+
+    return new MemberDetail(MemberResponse.from(member));
+  }
+}


### PR DESCRIPTION
### 변경사항

**AS-IS**
* 구글 로그인/회원가입 기능 구현
  * 프론트에서 요청시 구글 로그인 페이지 uri 넘겨주는 컨트롤러 생성
  * 프론트에서 Auth Code 넘겨받고 Access Token 교환 -> 유저 정보 받아오기
  * DB에 가입된 이메일이 있으면 로그인 처리, 없으면 회원가입+로그인 동시 처리
  * 구글에서 받아오는 정보는 이름(닉네임), 이메일 -> 나머지 회원정보(주종, 지역 등)는 빈 상태로 회원가입됨
    -> 회원가입후 마이페이지에서 설정 필요

* UserDetail 관련 클래스 생성 -> 백엔드 서버 접근시 JWT 필터에서 정보 확인후 Authentication 저장


**TO-BE**
* 현준님이 PR 하신 부분(TokenDTO 로 반환)은 아직 적용하지 못했습니다. 한번 머지후 반영해서 다시 PR 올리도록 하겠습니다.
* 프론트 분들께서 Auth Code 리다이렉션 받을 프론트 서버의 uri 주시면 반영 예정

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 