### PR TITLE
feat: 비밀번호 재설정 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.onedrinktoday.backend.domain.member.controller;
 
+import com.onedrinktoday.backend.domain.member.dto.ChangePasswordRequestDTO;
 import com.onedrinktoday.backend.domain.member.dto.MemberRequest;
 import com.onedrinktoday.backend.domain.member.dto.MemberResponse;
 import com.onedrinktoday.backend.domain.member.dto.PasswordResetDTO;
 import com.onedrinktoday.backend.domain.member.dto.PasswordResetRequest;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.global.security.JwtProvider;
 import com.onedrinktoday.backend.global.security.TokenDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
   private final MemberService memberService;
+  private final JwtProvider jwtProvider;
 
   @PostMapping("/members/signup")
   public ResponseEntity<MemberResponse> signUp(@Valid @RequestBody MemberRequest.SignUp request) {
@@ -42,16 +45,28 @@ public class MemberController {
     return ResponseEntity.ok().build();
   }
 
-  // 비밀번호 재설정 페이지로 리디렉션
-  @GetMapping("/members/reset-password")
+  // 비밀번호 재설정 페이지로 리디렉션(비밀번호 모를 경우)
+  @GetMapping("/members/password-reset")
   public ResponseEntity<String> showResetPasswordPage(@RequestParam String token) {
     // 실제로 HTML 템플릿을 렌더링, 프론트엔드 통합테스트 전에 예시로 텍스트+토큰 반환
     return ResponseEntity.ok("비밀번호 재설정 페이지. 토큰: " + token);
   }
 
-  @PostMapping("/members/reset-password")
+  // 비밀번호 모를 경우 재설정
+  @PostMapping("/members/password-reset")
   public ResponseEntity<Void> resetPassword(@Valid @RequestBody PasswordResetDTO request) {
     memberService.resetPassword(request.getToken(), request.getNewPassword());
+    return ResponseEntity.ok().build();
+  }
+
+  // 비밀번호 알 경우 재설정
+  @PostMapping("/members/password-change")
+  public ResponseEntity<Void> changePassword(@RequestHeader("Authorization") String token, @RequestBody ChangePasswordRequestDTO request) {
+
+    String email = jwtProvider.getEmail(token);
+
+    memberService.changePassword(email, request.getCurrentPassword(), request.getNewPassword());
+
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
@@ -2,13 +2,17 @@ package com.onedrinktoday.backend.domain.member.controller;
 
 import com.onedrinktoday.backend.domain.member.dto.MemberRequest;
 import com.onedrinktoday.backend.domain.member.dto.MemberResponse;
+import com.onedrinktoday.backend.domain.member.dto.PasswordResetDTO;
+import com.onedrinktoday.backend.domain.member.dto.PasswordResetRequest;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,7 +34,23 @@ public class MemberController {
     return ResponseEntity.ok(memberService.signIn(request));
   }
 
+  @PostMapping("/members/request-password-reset")
+  public ResponseEntity<Void> requestPasswordReset(@Valid @RequestBody PasswordResetRequest request) {
+    memberService.requestPasswordReset(request.getEmail());
+    return ResponseEntity.ok().build();
+  }
 
+  // 비밀번호 재설정 페이지로 리디렉션
+  @GetMapping("/members/reset-password")
+  public ResponseEntity<String> showResetPasswordPage(@RequestParam String token) {
+    // 실제로 HTML 템플릿을 렌더링, 프론트엔드 통합테스트 전에 예시로 텍스트+토큰 반환
+    return ResponseEntity.ok("비밀번호 재설정 페이지. 토큰: " + token);
+  }
 
+  @PostMapping("/members/reset-password")
+  public ResponseEntity<Void> resetPassword(@Valid @RequestBody PasswordResetDTO request) {
+    memberService.resetPassword(request.getToken(), request.getNewPassword());
+    return ResponseEntity.ok().build();
+  }
 
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/member/dto/ChangePasswordRequestDTO.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/dto/ChangePasswordRequestDTO.java
@@ -1,0 +1,22 @@
+package com.onedrinktoday.backend.domain.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChangePasswordRequestDTO {
+  @NotNull(message = "현재 비밀번호를 입력해주세요.")
+  private String currentPassword;
+
+  @NotNull(message = "새 비밀번호를 입력해주세요.")
+  @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[$@!%*?&])[A-Za-z\\d$@!%*?&]{8,15}",
+      message = "비밀번호는 8자 이상 15자 이하로, 소문자, 대문자, 숫자 및 특수문자를 모두 포함해야 합니다.")
+  private String newPassword;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/member/dto/PasswordResetDTO.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/dto/PasswordResetDTO.java
@@ -1,0 +1,25 @@
+package com.onedrinktoday.backend.domain.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PasswordResetDTO {
+
+  @NotNull(message = "토큰을 입력해주세요.")
+  private String token;
+
+  @NotNull(message = "새 비밀번호를 입력해주세요.")
+  @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[$@!%*?&])[A-Za-z\\d$@!%*?&]{8,15}",
+      message = "비밀번호는 8자 이상 15자 이하로, 소문자, 대문자, 숫자 및 특수문자를 모두 포함해야 합니다.")
+  private String newPassword;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/member/dto/PasswordResetRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/dto/PasswordResetRequest.java
@@ -1,0 +1,21 @@
+package com.onedrinktoday.backend.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PasswordResetRequest {
+
+  @NotNull(message = "이메일을 입력해주세요.")
+  @Email(message = "올바른 이메일 형식을 입력해주세요.")
+  private String email;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/member/service/EmailService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/service/EmailService.java
@@ -1,0 +1,23 @@
+package com.onedrinktoday.backend.domain.member.service;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+   private final JavaMailSender emailSender;
+
+   public EmailService(JavaMailSender emailSender) {
+     this.emailSender = emailSender;
+   }
+
+   public void sendPasswordResetEmail(String to, String resetLink) {
+     SimpleMailMessage message = new SimpleMailMessage();
+     message.setTo(to);
+     message.setSubject("비밀번호 재설정 요청");
+     message.setText("비밀번호를 재설정하려면 다음 링크를 클릭하세요: " + resetLink);
+     emailSender.send(message);
+ }
+}

--- a/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
@@ -10,9 +10,10 @@ public enum ErrorCode {
 
   CONVERT_ERROR("변환 에러", HttpStatus.BAD_REQUEST),
   EMAIL_EXIST("이미 가입된 메일입니다.", HttpStatus.BAD_REQUEST),
-  REGION_NOT_FOUND("지역을 찾을수 없습니다.", HttpStatus.BAD_REQUEST),
+  REGION_NOT_FOUND("지역을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
   REGION_EXIST("이미 존재하는 지역명입니다.", HttpStatus.BAD_REQUEST),
-  LOGIN_FAIL("이메일, 비밀번호를 확인해 주세요.", HttpStatus.BAD_REQUEST);
+  LOGIN_FAIL("이메일, 비밀번호를 확인해 주세요.", HttpStatus.BAD_REQUEST),
+  EMAIL_NOT_FOUND("이메일을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST);
 
   private final String message;
   private final HttpStatus status;

--- a/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
   REGION_NOT_FOUND("지역을 찾을수 없습니다.", HttpStatus.BAD_REQUEST),
   REGION_EXIST("이미 존재하는 지역명입니다.", HttpStatus.BAD_REQUEST),
   LOGIN_FAIL("이메일, 비밀번호를 확인해 주세요.", HttpStatus.BAD_REQUEST),
+  SAME_PASSWORD("새 비밀번호가 기존 비밀번호와 동일합니다.", HttpStatus.BAD_REQUEST),
   TOKEN_EXPIRED("토큰이 유효 기간이 지나서 만료되었습니다.", HttpStatus.UNAUTHORIZED),
   INVALID_REFRESH_TOKEN("리프레시 토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
   ACCESS_DENIED("접근이 거부되었습니다.", HttpStatus.FORBIDDEN);


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 비밀번호 재설정 기능 추가
  - 비밀번호 재설정 요청 : 사용자가 이메일 제출하면, 해당 이메일을 찾고 비밀번호 재설정 토큰을 생성하여 이메일로 전송
  - JwtProvider에서 비밀번호 재설정 토큰 기한 설정 및 토큰 생성 메서드 추가
  - MemberService의 requestPasswordReset 메서드 통해, JwtProvider에서 생성한 토큰을 사용하여 비밀번호 재설정 링크가 이메일로 발송
  - EmailService의 sendPasswordResetEmail 메서드 통해, 이메일 발송 처리

- 비밀번호 재설정 처리
  - 사용자가 이메일로 받은 링크에서 토큰을 포함해 비밀번호 재설정하는 API 추가
  - 해당 API는 토큰의 유효성 검증 후, 새로운 비밀번호로 사용자 계정의 비밀번호를 업데이트 
  - 비밀번호 재설정 요청 `/members/request-password-reset` : 사용자가 이메일을 입력하면 비밀번호 재설정 링크 발송
  - 비밀번호 재설정 `/members/reset-password` : 사용자가 재설정 페이지에서 새로운 비밀번호를 입력하면, 해당 비밀번호로 계정 업데이트

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 