### PR TITLE
feat: 게시글 기능 구현

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/drink/dto/DrinkDTO.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/drink/dto/DrinkDTO.java
@@ -1,0 +1,42 @@
+package com.onedrinktoday.backend.domain.drink.dto;
+
+import com.onedrinktoday.backend.domain.drink.entity.Drink;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrinkDTO {
+  private Long id;
+  private String placeName;
+  private String name;
+  private String drinkType;
+  private Integer degree;
+  private Integer sweetness;
+  private Integer cost;
+  private String description;
+  private String imageUrl;
+  private Timestamp createdAt;
+
+  public static DrinkDTO from(Drink drink) {
+    return DrinkDTO.builder()
+        .id(drink.getId())
+        .placeName(drink.getRegion().getPlaceName())
+        .name(drink.getName())
+        .drinkType(drink.getDrink().name())
+        .degree(drink.getDegree())
+        .sweetness(drink.getSweetness())
+        .cost(drink.getCost())
+        .description(drink.getDescription())
+        .imageUrl(drink.getImageUrl())
+        .createdAt(drink.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/drink/dto/DrinkDTO.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/drink/dto/DrinkDTO.java
@@ -17,7 +17,7 @@ public class DrinkDTO {
   private Long id;
   private String placeName;
   private String name;
-  private String drinkType;
+  private com.onedrinktoday.backend.global.type.Drink drinkType;
   private Integer degree;
   private Integer sweetness;
   private Integer cost;
@@ -30,7 +30,7 @@ public class DrinkDTO {
         .id(drink.getId())
         .placeName(drink.getRegion().getPlaceName())
         .name(drink.getName())
-        .drinkType(drink.getDrink().name())
+        .drinkType(drink.getDrink())
         .degree(drink.getDegree())
         .sweetness(drink.getSweetness())
         .cost(drink.getCost())

--- a/src/main/java/com/onedrinktoday/backend/domain/drink/entity/Drink.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/drink/entity/Drink.java
@@ -1,0 +1,61 @@
+package com.onedrinktoday.backend.domain.drink.entity;
+
+import com.onedrinktoday.backend.domain.region.entity.Region;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "drink")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Drink {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "region_id")
+  private Region region;
+
+  @Column(name = "name", nullable = false, length = 100)
+  private String name;
+
+  @Enumerated(EnumType.STRING)
+  private com.onedrinktoday.backend.global.type.Drink drink;
+
+  @Column(name = "degree", nullable = true)
+  private Integer degree;
+
+  @Column(name = "sweetness", nullable = true)
+  private Integer sweetness;
+
+  @Column(name = "cost", nullable = true)
+  private Integer cost;
+
+  @Column(name = "description", columnDefinition = "TEXT", nullable = false)
+  private String description;
+
+  @Column(name = "image_url", nullable = false)
+  private String imageUrl;
+
+  @CreationTimestamp
+  private Timestamp createdAt;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/drink/repository/DrinkRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/drink/repository/DrinkRepository.java
@@ -1,0 +1,9 @@
+package com.onedrinktoday.backend.domain.drink.repository;
+
+import com.onedrinktoday.backend.domain.drink.entity.Drink;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DrinkRepository extends JpaRepository<Drink, Long> {
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
@@ -57,8 +57,8 @@ public class MemberService {
       throw new CustomException(ErrorCode.LOGIN_FAIL);
     }
 
-    String accessToken = jwtProvider.createAccessToken(member.getEmail(), member.getRole());
-    String refreshToken = jwtProvider.createRefreshToken(member.getEmail(), member.getRole());
+    String accessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail(), member.getRole());
+    String refreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail(), member.getRole());
     member.setRefreshToken(refreshToken);
     memberRepository.save(member);
 
@@ -89,7 +89,7 @@ public class MemberService {
       throw new CustomException(ErrorCode.TOKEN_NOT_MATCH);
     }
 
-    String accessToken = jwtProvider.createAccessToken(member.getEmail(), member.getRole());
+    String accessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail(), member.getRole());
 
     return TokenDto.builder()
         .refreshToken(refreshToken)
@@ -132,7 +132,7 @@ public class MemberService {
     Member member = memberRepository.findByEmail(email)
         .orElseThrow(() -> new CustomException(ErrorCode.EMAIL_NOT_FOUND));
 
-    String token = jwtProvider.createResetToken(member.getEmail(), member.getRole());
+    String token = jwtProvider.createResetToken(member.getId(), member.getEmail(), member.getRole());
 
     // 도메인 변경(예정)
     String resetLink = "http://localhost:8080/api/members/reset-password?token=" + token;

--- a/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
@@ -6,6 +6,7 @@ import com.onedrinktoday.backend.domain.post.service.PostService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,5 +37,11 @@ public class PostController {
   public ResponseEntity<PostResponse> getPostById(@PathVariable Long postId) {
     PostResponse postResponse = postService.getPostById(postId);
     return ResponseEntity.ok(postResponse);
+  }
+
+  @DeleteMapping("/posts/{postId}")
+  public ResponseEntity<Void> deletePostById(@PathVariable Long postId) {
+    postService.deletePostById(postId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
@@ -3,8 +3,10 @@ package com.onedrinktoday.backend.domain.post.controller;
 import com.onedrinktoday.backend.domain.post.dto.PostRequest;
 import com.onedrinktoday.backend.domain.post.dto.PostResponse;
 import com.onedrinktoday.backend.domain.post.service.PostService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,8 +32,10 @@ public class PostController {
   }
 
   @GetMapping("/posts")
-  public ResponseEntity<List<PostResponse>> getAllPosts() {
-    List<PostResponse> posts = postService.getAllPosts();
+  public ResponseEntity<Page<PostResponse>> getAllPosts(@RequestParam(defaultValue = "0") int page,
+                                                        @RequestParam(defaultValue = "10") int size) {
+    Pageable pageable = PageRequest.of(page, size);
+    Page<PostResponse> posts = postService.getAllPosts(pageable);
     return ResponseEntity.ok(posts);
   }
 

--- a/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
@@ -3,8 +3,10 @@ package com.onedrinktoday.backend.domain.post.controller;
 import com.onedrinktoday.backend.domain.post.dto.PostRequest;
 import com.onedrinktoday.backend.domain.post.dto.PostResponse;
 import com.onedrinktoday.backend.domain.post.service.PostService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,5 +23,11 @@ public class PostController {
   public ResponseEntity<PostResponse> post(@RequestHeader("member_id") Long memberId, @RequestBody PostRequest postRequest) {
     PostResponse postResponse = postService.createPost(memberId, postRequest);
     return ResponseEntity.ok(postResponse);
+  }
+
+  @GetMapping("/posts")
+  public ResponseEntity<List<PostResponse>> getAllPosts() {
+    List<PostResponse> posts = postService.getAllPosts();
+    return ResponseEntity.ok(posts);
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -29,5 +30,11 @@ public class PostController {
   public ResponseEntity<List<PostResponse>> getAllPosts() {
     List<PostResponse> posts = postService.getAllPosts();
     return ResponseEntity.ok(posts);
+  }
+
+  @GetMapping("/posts/{postId}")
+  public ResponseEntity<PostResponse> getPostById(@PathVariable Long postId) {
+    PostResponse postResponse = postService.getPostById(postId);
+    return ResponseEntity.ok(postResponse);
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
@@ -1,0 +1,25 @@
+package com.onedrinktoday.backend.domain.post.controller;
+
+import com.onedrinktoday.backend.domain.post.dto.PostRequest;
+import com.onedrinktoday.backend.domain.post.dto.PostResponse;
+import com.onedrinktoday.backend.domain.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class PostController {
+  private final PostService postService;
+
+  @PostMapping("/posts")
+  public ResponseEntity<PostResponse> post(@RequestHeader("member_id") Long memberId, @RequestBody PostRequest postRequest) {
+    PostResponse postResponse = postService.createPost(memberId, postRequest);
+    return ResponseEntity.ok(postResponse);
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,5 +44,11 @@ public class PostController {
   public ResponseEntity<Void> deletePostById(@PathVariable Long postId) {
     postService.deletePostById(postId);
     return ResponseEntity.noContent().build();
+  }
+
+  @PutMapping("/posts/{postId}")
+  public ResponseEntity<PostResponse> updatePostById(@PathVariable Long postId, @RequestBody PostRequest postRequest) {
+    PostResponse updatedPost = postService.updatePost(postId, postRequest);
+    return ResponseEntity.ok(updatedPost);
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostRequest.java
@@ -16,7 +16,6 @@ public class PostRequest {
   private Long drinkId;
   private Long memberId;
   private String type;
-  private String title;
   private String content;
   private Float rating;
   private List<String> tag;

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostRequest.java
@@ -1,6 +1,5 @@
 package com.onedrinktoday.backend.domain.post.dto;
 
-import com.onedrinktoday.backend.domain.drink.entity.Drink;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,10 +13,20 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostRequest {
-  private Drink drink;
+  private Long drinkId;
   private String type;
   private String title;
   private String content;
   private Float rating;
   private List<String> tag;
+
+  // 새 음료 입력
+  private String drinkName;
+  private String description;
+  private Integer degree;
+  private Integer sweetness;
+  private Integer cost;
+  private String imageUrl;
+  private Long regionId;
+  private com.onedrinktoday.backend.global.type.Drink drinkType;
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostRequest.java
@@ -1,0 +1,23 @@
+package com.onedrinktoday.backend.domain.post.dto;
+
+import com.onedrinktoday.backend.domain.drink.entity.Drink;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequest {
+  private Drink drink;
+  private String type;
+  private String title;
+  private String content;
+  private Float rating;
+  private List<String> tag;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostRequest.java
@@ -14,6 +14,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class PostRequest {
   private Long drinkId;
+  private Long memberId;
   private String type;
   private String title;
   private String content;

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
@@ -24,7 +24,6 @@ public class PostResponse {
   private String memberName;
   private DrinkDTO drink;
   private String type;
-  private String title;
   private String content;
   private Float rating;
   private List<TagDTO> tags;
@@ -39,7 +38,6 @@ public class PostResponse {
         .memberName(post.getMember().getName())
         .drink(DrinkDTO.from(post.getDrink()))
         .type(post.getType().name())
-        .title(post.getTitle())
         .content(post.getContent())
         .rating(post.getRating())
         .tags(tags.stream().map(TagDTO::from).collect(Collectors.toList()))
@@ -53,7 +51,6 @@ public class PostResponse {
   public static PostResponse from(Post post) {
     return PostResponse.builder()
         .id(post.getId())
-        .title(post.getTitle())
         .content(post.getContent())
         .rating(post.getRating())
         .viewCount(post.getViewCount())

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
@@ -31,7 +31,7 @@ public class PostResponse {
   private Timestamp createdAt;
   private Timestamp updatedAt;
 
-  public static PostResponse from(Post post, List<Tag> tags) {
+  public static PostResponse of(Post post, List<Tag> tags) {
     return PostResponse.builder()
         .id(post.getId())
         .memberId(post.getMember().getId())

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
@@ -1,0 +1,51 @@
+package com.onedrinktoday.backend.domain.post.dto;
+
+import com.onedrinktoday.backend.domain.drink.dto.DrinkDTO;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.tag.dto.TagDTO;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostResponse {
+  private Long id;
+  private Long memberId;
+  private String memberName;
+  private DrinkDTO drink;
+  private String type;
+  private String title;
+  private String content;
+  private Float rating;
+  private List<TagDTO> tags;
+  private Integer viewCount;
+  private Timestamp createdAt;
+  private Timestamp updatedAt;
+
+  public static PostResponse from(Post post, List<Tag> tags) {
+    return PostResponse.builder()
+        .id(post.getId())
+        .memberId(post.getMember().getId())
+        .memberName(post.getMember().getName())
+        .drink(DrinkDTO.from(post.getDrink()))
+        .type(post.getType().name())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .rating(post.getRating())
+        .tags(tags.stream().map(TagDTO::from).collect(Collectors.toList()))
+        .viewCount(post.getViewCount())
+        .createdAt(post.getCreatedAt())
+        .updatedAt(post.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
@@ -48,4 +48,17 @@ public class PostResponse {
         .updatedAt(post.getUpdatedAt())
         .build();
   }
+
+  // post 엔티티 변환
+  public static PostResponse from(Post post) {
+    return PostResponse.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .rating(post.getRating())
+        .viewCount(post.getViewCount())
+        .createdAt(post.getCreatedAt())
+        .drink(DrinkDTO.from(post.getDrink()))
+        .build();
+  }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/entity/Post.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/entity/Post.java
@@ -50,9 +50,6 @@ public class Post {
   @Enumerated(EnumType.STRING)
   private Type type;
 
-  @Column(name = "title", length = 255, nullable = false)
-  private String title;
-
   @Column(name = "content", columnDefinition = "TEXT", nullable = false)
   private String content;
 

--- a/src/main/java/com/onedrinktoday/backend/domain/post/entity/Post.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/entity/Post.java
@@ -1,0 +1,72 @@
+package com.onedrinktoday.backend.domain.post.entity;
+
+import com.onedrinktoday.backend.domain.drink.entity.Drink;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.global.type.Type;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "post")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE post SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+public class Post {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @ManyToOne
+  @JoinColumn(name = "drink_id")
+  private Drink drink;
+
+  @Enumerated(EnumType.STRING)
+  private Type type;
+
+  @Column(name = "title", length = 255, nullable = false)
+  private String title;
+
+  @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+  private String content;
+
+  @Column(name = "rating", nullable = true)
+  private Float rating;
+
+  @Column(name = "view_count", nullable = true)
+  private Integer viewCount;
+
+  @CreationTimestamp
+  private Timestamp createdAt;
+
+  @UpdateTimestamp
+  private Timestamp updatedAt;
+
+  private Timestamp deletedAt;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package com.onedrinktoday.backend.domain.post.repository;
+
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -73,7 +73,6 @@ public class PostService {
         .member(member)
         .drink(drink)
         .type(Type.valueOf(postRequest.getType()))
-        .title(postRequest.getTitle())
         .content(postRequest.getContent())
         .rating(postRequest.getRating())
         .viewCount(0)  // 초기 조회수
@@ -134,7 +133,6 @@ public class PostService {
     Post post = postRepository.findById(postId)
         .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 게시글 ID입니다."));
 
-    post.setTitle(postRequest.getTitle());
     post.setContent(postRequest.getContent());
     post.setRating(postRequest.getRating());
 

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -15,6 +15,7 @@ import com.onedrinktoday.backend.domain.region.repository.RegionRepository;
 import com.onedrinktoday.backend.domain.tag.entity.Tag;
 import com.onedrinktoday.backend.domain.tag.repository.TagRepository;
 import com.onedrinktoday.backend.global.type.Type;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -142,6 +143,7 @@ public class PostService {
   }
 
   // 게시글 수정
+  @Transactional
   public PostResponse updatePost(Long postId, PostRequest postRequest) {
     Post post = postRepository.findById(postId)
         .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 게시글 ID입니다."));
@@ -164,7 +166,11 @@ public class PostService {
 
     postRepository.save(post);
 
+    // 기존 태그 삭제
+    postTagRepository.deleteByPostId(postId);
     List<Tag> updateTag = saveTags(postRequest.getTag(), post);
+
+    postRepository.save(post);
 
     return PostResponse.of(post, updateTag);
   }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -86,7 +86,7 @@ public class PostService {
     // 태그 저장 및 PostTag 연결
     List<Tag> tags = saveTags(postRequest.getTag(), post);
 
-    return PostResponse.from(post, tags);
+    return PostResponse.of(post, tags);
   }
 
   // 태그 저장
@@ -130,7 +130,7 @@ public class PostService {
     // 태그 함께 조회
     List<Tag> tags = postTagRepository.findTagsByPostId(postId);
 
-    return PostResponse.from(post, tags);
+    return PostResponse.of(post, tags);
   }
 
   // 게시글 삭제
@@ -166,6 +166,6 @@ public class PostService {
 
     List<Tag> updateTag = saveTags(postRequest.getTag(), post);
 
-    return PostResponse.from(post, updateTag);
+    return PostResponse.of(post, updateTag);
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -128,4 +128,33 @@ public class PostService {
     }
     postRepository.deleteById(postId);
   }
+
+  // 게시글 수정
+  public PostResponse updatePost(Long postId, PostRequest postRequest) {
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 게시글 ID입니다."));
+
+    post.setTitle(postRequest.getTitle());
+    post.setContent(postRequest.getContent());
+    post.setRating(postRequest.getRating());
+
+    // 음료 정보 수정할 시
+    if(postRequest.getDrinkId() != null) {
+      Drink drink = drinkRepository.findById(postRequest.getDrinkId())
+          .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 특산주입니다."));
+      post.setDrink(drink);
+    }
+
+    if (postRequest.getMemberId() != null) {
+      Member member = memberRepository.findById(postRequest.getMemberId())
+          .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+      post.setMember(member);
+    }
+
+    postRepository.save(post);
+
+    List<Tag> updateTag = saveTags(postRequest.getTag(), post);
+
+    return PostResponse.from(post, updateTag);
+  }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -96,10 +96,14 @@ public class PostService {
             newTag.setTagName(tagName);
             return tagRepository.save(newTag);
           });
-      PostTag postTag = new PostTag();
-      postTag.setPost(post);
-      postTag.setTag(tag);
-      postTagRepository.save(postTag);
+
+      postTagRepository.findByPostAndTag(post, tag)
+          .orElseGet(() -> {
+            PostTag newPostTag = new PostTag();
+            newPostTag.setPost(post);
+            newPostTag.setTag(tag);
+            return postTagRepository.save(newPostTag);
+          });
 
       return tag;
     }).collect(Collectors.toList());

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -18,6 +18,8 @@ import com.onedrinktoday.backend.global.type.Type;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -110,11 +112,10 @@ public class PostService {
   }
 
   // 전체 게시글 조회
-  public List<PostResponse> getAllPosts() {
-    List<Post> Posts = postRepository.findAll();
-    return Posts.stream()
-        .map(PostResponse::from)
-        .collect(Collectors.toList());
+  public Page<PostResponse> getAllPosts(Pageable pageable) {
+    Page<Post> Posts = postRepository.findAll(pageable);
+
+    return Posts.map(PostResponse::from);
   }
 
   // 특정 게시글 조회

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -117,7 +117,15 @@ public class PostService {
   public PostResponse getPostById(Long postId) {
     Post post = postRepository.findById(postId)
         .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 게시글 ID입니다."));
-    return PostResponse.from(post);
+
+    // viewCount 증가
+    post.setViewCount(post.getViewCount() + 1);
+    postRepository.save(post);
+
+    // 태그 함께 조회
+    List<Tag> tags = postTagRepository.findTagsByPostId(postId);
+
+    return PostResponse.from(post, tags);
   }
 
   // 게시글 삭제

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -1,0 +1,123 @@
+package com.onedrinktoday.backend.domain.post.service;
+
+import com.onedrinktoday.backend.domain.drink.entity.Drink;
+import com.onedrinktoday.backend.domain.drink.repository.DrinkRepository;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
+import com.onedrinktoday.backend.domain.post.dto.PostRequest;
+import com.onedrinktoday.backend.domain.post.dto.PostResponse;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.post.repository.PostRepository;
+import com.onedrinktoday.backend.domain.postTag.entity.PostTag;
+import com.onedrinktoday.backend.domain.postTag.repository.PostTagRepository;
+import com.onedrinktoday.backend.domain.region.entity.Region;
+import com.onedrinktoday.backend.domain.region.repository.RegionRepository;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import com.onedrinktoday.backend.domain.tag.repository.TagRepository;
+import com.onedrinktoday.backend.global.type.Type;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+  private final PostRepository postRepository;
+  private final MemberRepository memberRepository;
+  private final DrinkRepository drinkRepository;
+  private final TagRepository tagRepository;
+  private final PostTagRepository postTagRepository;
+  private final RegionRepository regionRepository;
+
+  // 게시글 생성 및 저장
+  public PostResponse createPost(Long memberId, PostRequest postRequest) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+
+    Drink drink;
+
+    // 이미 등록된 특산주 사용
+    if (postRequest.getDrinkId() != null) {
+      drink = drinkRepository.findById(postRequest.getDrinkId())
+          .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 특산주입니다."));
+    }
+
+    // 새 특산주 등록 시
+    else {
+      if (postRequest.getDrinkName() == null || postRequest.getRegionId() == null) {
+        throw new IllegalArgumentException("음료 이름과 지역 ID는 필수입니다.");
+      }
+
+      // 지역 유효성 검사
+      Region region = regionRepository.findById(postRequest.getRegionId())
+          .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 지역입니다."));
+
+      drink = Drink.builder()
+          .name(postRequest.getDrinkName())
+          .description(postRequest.getDescription())
+          .degree(postRequest.getDegree())
+          .sweetness(postRequest.getSweetness())
+          .cost(postRequest.getCost())
+          .imageUrl(postRequest.getImageUrl())
+          .drink(postRequest.getDrinkType())
+          .region(region)
+          .build();
+
+      drink = drinkRepository.save(drink);
+    }
+
+    // 게시글 엔티티 생성
+    Post post = Post.builder()
+        .member(member)
+        .drink(drink)
+        .type(Type.valueOf(postRequest.getType()))
+        .title(postRequest.getTitle())
+        .content(postRequest.getContent())
+        .rating(postRequest.getRating())
+        .viewCount(0)  // 초기 조회수
+        .build();
+
+    // 게시글 저장
+    post = postRepository.save(post);
+
+    // 태그 저장 및 PostTag 연결
+    List<Tag> tags = saveTags(postRequest.getTag(), post);
+
+    return PostResponse.from(post, tags);
+  }
+
+  // 태그 저장
+  private List<Tag> saveTags(List<String> tagNames, Post post) {
+    return tagNames.stream().map(tagName -> {
+      Tag tag = tagRepository.findByTagName(tagName)
+          .orElseGet(() -> {
+            Tag newTag = new Tag();
+            newTag.setTagName(tagName);
+            return tagRepository.save(newTag);
+          });
+      PostTag postTag = new PostTag();
+      postTag.setPost(post);
+      postTag.setTag(tag);
+      postTagRepository.save(postTag);
+
+      return tag;
+    }).collect(Collectors.toList());
+  }
+
+  // 전체 게시글 조회
+  public List<PostResponse> getAllPosts() {
+    List<Post> Posts = postRepository.findAll();
+    return Posts.stream()
+        .map(PostResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  // 특정 게시글 조회
+  public PostResponse getPostById(Long postId) {
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 게시글 ID입니다."));
+    return PostResponse.from(post);
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -120,4 +120,12 @@ public class PostService {
         .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 게시글 ID입니다."));
     return PostResponse.from(post);
   }
+
+  // 게시글 삭제
+  public void deletePostById(Long postId) {
+    if(!postRepository.existsById(postId)) {
+      throw new IllegalArgumentException("유효하지 않은 게시글 ID입니다.");
+    }
+    postRepository.deleteById(postId);
+  }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/postTag/entity/PostTag.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/postTag/entity/PostTag.java
@@ -1,0 +1,40 @@
+package com.onedrinktoday.backend.domain.postTag.entity;
+
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "post_tag")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostTag {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "posted_tag_id")
+  private Long postedTagId;
+
+  @ManyToOne
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+
+  @ManyToOne
+  @JoinColumn(name = "tag_id", nullable = false)
+  private Tag tag;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/postTag/repository/PostTagRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/postTag/repository/PostTagRepository.java
@@ -1,0 +1,10 @@
+package com.onedrinktoday.backend.domain.postTag.repository;
+
+import com.onedrinktoday.backend.domain.postTag.entity.PostTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostTagRepository extends JpaRepository<PostTag, Long> {
+
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/postTag/repository/PostTagRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/postTag/repository/PostTagRepository.java
@@ -1,8 +1,10 @@
 package com.onedrinktoday.backend.domain.postTag.repository;
 
+import com.onedrinktoday.backend.domain.post.entity.Post;
 import com.onedrinktoday.backend.domain.postTag.entity.PostTag;
 import com.onedrinktoday.backend.domain.tag.entity.Tag;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +13,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 
-  @Query("SELECT pt.tag FROM PostTag pt WHERE pt.postedTagId = :postId")
+  // 특정 게시글 연결 태그 조회
+  @Query("SELECT pt.tag FROM PostTag pt WHERE pt.post.id = :postId")
   List<Tag> findTagsByPostId(@Param("postId") Long postId);
+
+  Optional<PostTag> findByPostAndTag(Post post, Tag tag);
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/postTag/repository/PostTagRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/postTag/repository/PostTagRepository.java
@@ -1,10 +1,16 @@
 package com.onedrinktoday.backend.domain.postTag.repository;
 
 import com.onedrinktoday.backend.domain.postTag.entity.PostTag;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 
+  @Query("SELECT pt.tag FROM PostTag pt WHERE pt.postedTagId = :postId")
+  List<Tag> findTagsByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/postTag/repository/PostTagRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/postTag/repository/PostTagRepository.java
@@ -6,6 +6,7 @@ import com.onedrinktoday.backend.domain.tag.entity.Tag;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -16,6 +17,11 @@ public interface PostTagRepository extends JpaRepository<PostTag, Long> {
   // 특정 게시글 연결 태그 조회
   @Query("SELECT pt.tag FROM PostTag pt WHERE pt.post.id = :postId")
   List<Tag> findTagsByPostId(@Param("postId") Long postId);
+
+  // 게시글 수정 시 게시글에 연결된 태그 삭제
+  @Modifying
+  @Query("DELETE FROM PostTag pt WHERE pt.post.id = :postId")
+  void deleteByPostId(@Param("postId") Long postId);
 
   Optional<PostTag> findByPostAndTag(Post post, Tag tag);
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/tag/dto/TagDTO.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tag/dto/TagDTO.java
@@ -1,0 +1,17 @@
+package com.onedrinktoday.backend.domain.tag.dto;
+
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import lombok.Data;
+
+@Data
+public class TagDTO {
+  private Long tagId;
+  private String tagName;
+
+  public static TagDTO from(Tag tag) {
+    TagDTO dto = new TagDTO();
+    dto.setTagId(tag.getTagId());
+    dto.setTagName(tag.getTagName());
+    return dto;
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/tag/entity/Tag.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tag/entity/Tag.java
@@ -1,0 +1,31 @@
+package com.onedrinktoday.backend.domain.tag.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "tag")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Tag {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "tag_id")
+  private Long tagId;
+
+  @Column(name = "name", nullable = false)
+  private String tagName;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tag/repository/TagRepository.java
@@ -1,0 +1,11 @@
+package com.onedrinktoday.backend.domain.tag.repository;
+
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+  Optional<Tag> findByTagName(String tagName);
+}

--- a/src/main/java/com/onedrinktoday/backend/global/security/GoogleService.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/GoogleService.java
@@ -56,8 +56,8 @@ public class GoogleService {
             .build())
         );
 
-    String accessToken = jwtProvider.createAccessToken(member.getEmail(), member.getRole());
-    String refreshToken = jwtProvider.createRefreshToken(member.getEmail(), member.getRole());
+    String accessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail(), member.getRole());
+    String refreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail(), member.getRole());
 
     return TokenDto.builder()
         .accessToken(accessToken)

--- a/src/main/java/com/onedrinktoday/backend/global/security/JwtProvider.java
+++ b/src/main/java/com/onedrinktoday/backend/global/security/JwtProvider.java
@@ -1,6 +1,7 @@
 package com.onedrinktoday.backend.global.security;
 
 import com.onedrinktoday.backend.global.type.Role;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -23,9 +24,10 @@ public class JwtProvider {
         Jwts.SIG.HS256.key().build().getAlgorithm());
   }
 
-  public String createAccessToken(String email, Role role) {
+  public String createAccessToken(Long memberId, String email, Role role) {
     return Jwts.builder()
         .subject(email)
+        .claim("member_id", memberId)
         .claim("role", role)
         .issuedAt(new Date())
         .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
@@ -33,9 +35,10 @@ public class JwtProvider {
         .compact();
   }
 
-  public String createRefreshToken(String email, Role role) {
+  public String createRefreshToken(Long memberId, String email, Role role) {
     return Jwts.builder()
         .subject(email)
+        .claim("member_id", memberId)
         .claim("role", role)
         .issuedAt(new Date())
         .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME))
@@ -44,9 +47,10 @@ public class JwtProvider {
   }
 
   // 비밀번호 재설정 토큰 생성
-  public String createResetToken(String email, Role role) {
+  public String createResetToken(Long memberId, String email, Role role) {
     return Jwts.builder()
         .subject(email)
+        .claim("member_id", memberId)
         .claim("role", role)
         .issuedAt(new Date())
         .expiration(new Date(System.currentTimeMillis() + PASSWORD_RESET_EXPIRE_TIME))
@@ -57,5 +61,15 @@ public class JwtProvider {
   public String getEmail(String token) {
     return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
         .getSubject();
+  }
+
+  public Long getMemberId(String token) {
+    Claims claims = Jwts.parser()
+        .verifyWith(secretKey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+
+    return claims.get("member_id", Long.class);  // member_id 추출
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/global/type/Type.java
+++ b/src/main/java/com/onedrinktoday/backend/global/type/Type.java
@@ -1,0 +1,5 @@
+package com.onedrinktoday.backend.global.type;
+
+public enum Type {
+  AD, REVIEW
+}

--- a/src/test/java/com/onedrinktoday/backend/global/security/GoogleServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/global/security/GoogleServiceTest.java
@@ -4,6 +4,7 @@ package com.onedrinktoday.backend.global.security;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 import com.onedrinktoday.backend.domain.member.entity.Member;
@@ -44,10 +45,10 @@ class GoogleServiceTest {
     given(memberRepository.save(any()))
         .willReturn(member);
 
-    given(jwtProvider.createAccessToken(anyString(), any()))
+    given(jwtProvider.createAccessToken(eq(1L), anyString(), eq(Role.USER)))
         .willReturn("access");
 
-    given(jwtProvider.createRefreshToken(anyString(), any()))
+    given(jwtProvider.createRefreshToken(eq(1L), anyString(), eq(Role.USER)))
         .willReturn("refresh");
 
     //when


### PR DESCRIPTION
### 변경사항

**AS-IS**

- 게시글 등록 기능 구현
  - 게시글 CRUD 기능 구현을 위해 연관된 Drink, Tag, PostTag 패키지를 추가하였고, 엔티티, 레포지토리, DTO 작성
  - 게시글 타입(광고, 리뷰) ENUM 작성
  - 게시글 생성 시 이미 등록된 특산주(Drink)를 사용하거나, 새로운 특산주 정보를 함께 입력 가능하도록 구현
  - 게시글에 태그(Tag)를 추가할 수 있도록 Tag 및 PostTag 엔티티 작성
  - 게시글 작성 후 태그를 PostTag 엔티티를 통해 연결하여 저장하는 로직 구현
  - 게시글 생성 시 기본적인 검증 로직 추가(유효한 사용자와 특산주 여부 검증)
  - 새로 등록된 음료 정보는 Drink 테이블에 저장되며, 게시글 작성 시 해당 음료 정보와 연관됨

- 게시글 조회 기능 구현
  - (GET /api/posts), 모든 게시글을 반환하며, 연관된 특산주 정보와 태그 정보도 포함
  - 특정 게시글 조회 기능 구현 -> (GET /api/posts/{postId}), 게시글 ID로 조회 가능하며 연관된 데이터 반환

- 게시글 수정 기능 구현
  - (PUT /api/posts/{postId}), 기존 게시글을 수정할 수 있으며, 특산주 및 태그 정보도 업데이트 가능 

- 게시글 삭제 기능 구현
  - (DELETE /api/posts/{postId}), soft delete 방식으로 삭제 처리되어 DB에서 즉시 삭제되지 않도록 구현 

TO-BE

- 각 기능 구현에 따른 테스트 코드 작성 예정


### 테스트
- [ ] 테스트 코드
- [x] API 테스트 