### PR TITLE
feat: Tag Follow 기능 구현

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/controller/TagFollowController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/controller/TagFollowController.java
@@ -3,7 +3,6 @@ package com.onedrinktoday.backend.domain.tagFollow.controller;
 import com.onedrinktoday.backend.domain.tagFollow.dto.TagFollowRequest;
 import com.onedrinktoday.backend.domain.tagFollow.dto.TagFollowResponse;
 import com.onedrinktoday.backend.domain.tagFollow.service.TagFollowService;
-import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,19 +22,20 @@ public class TagFollowController {
   private final TagFollowService tagFollowService;
 
   @PostMapping("/tags/follows")
-  public TagFollowResponse followTag(@Valid @RequestBody TagFollowRequest request) {
+  public TagFollowResponse followTag(@RequestBody TagFollowRequest request) {
 
     return tagFollowService.followTag(request);
   }
 
-  @GetMapping("/members/{memberId}/tags/follows")
-  public List<TagFollowResponse> getTagFollows(@PathVariable Long memberId) {
+  @GetMapping("/members/tags/follows")
+  public List<TagFollowResponse> getTagFollows() {
 
-    return tagFollowService.getTagFollows(memberId);
+    return tagFollowService.getTagFollows();
   }
 
   @DeleteMapping("/tags/follows/{followId}")
   public ResponseEntity<String> deleteTagFollow(@PathVariable Long followId) {
+
     tagFollowService.deleteTagFollow(followId);
     return ResponseEntity.ok("팔로우 태그가 삭제되었습니다.");
   }

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/controller/TagFollowController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/controller/TagFollowController.java
@@ -1,0 +1,41 @@
+package com.onedrinktoday.backend.domain.tagFollow.controller;
+
+import com.onedrinktoday.backend.domain.tagFollow.dto.TagFollowRequest;
+import com.onedrinktoday.backend.domain.tagFollow.dto.TagFollowResponse;
+import com.onedrinktoday.backend.domain.tagFollow.service.TagFollowService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TagFollowController {
+
+  private final TagFollowService tagFollowService;
+
+  @PostMapping("/tags/follows")
+  public TagFollowResponse followTag(@Valid @RequestBody TagFollowRequest request) {
+
+    return tagFollowService.followTag(request);
+  }
+
+  @GetMapping("/members/{memberId}/tags/follows")
+  public List<TagFollowResponse> getTagFollows(@PathVariable Long memberId) {
+
+    return tagFollowService.getTagFollows(memberId);
+  }
+
+  @DeleteMapping("/tags/follows/{followId}")
+  public void deleteTagFollow(@PathVariable Long followId) {
+    tagFollowService.deleteTagFollow(followId);
+  }
+
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/controller/TagFollowController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/controller/TagFollowController.java
@@ -6,6 +6,7 @@ import com.onedrinktoday.backend.domain.tagFollow.service.TagFollowService;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,8 +35,8 @@ public class TagFollowController {
   }
 
   @DeleteMapping("/tags/follows/{followId}")
-  public void deleteTagFollow(@PathVariable Long followId) {
+  public ResponseEntity<String> deleteTagFollow(@PathVariable Long followId) {
     tagFollowService.deleteTagFollow(followId);
+    return ResponseEntity.ok("팔로우 태그가 삭제되었습니다.");
   }
-
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/dto/TagFollowRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/dto/TagFollowRequest.java
@@ -1,5 +1,6 @@
 package com.onedrinktoday.backend.domain.tagFollow.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,5 +12,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class TagFollowRequest {
 
+  @NotBlank
   private Long tagId;
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/dto/TagFollowRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/dto/TagFollowRequest.java
@@ -1,0 +1,15 @@
+package com.onedrinktoday.backend.domain.tagFollow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TagFollowRequest {
+
+  private Long tagId;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/dto/TagFollowResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/dto/TagFollowResponse.java
@@ -14,7 +14,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class TagFollowResponse {
 
-  private Long followId;
+  private Long id;
   private Long memberId;
   private String memberName;
   private Long tagId;
@@ -22,7 +22,7 @@ public class TagFollowResponse {
 
   public static TagFollowResponse from(TagFollow tagFollow) {
     return TagFollowResponse.builder()
-        .followId(tagFollow.getId())
+        .id(tagFollow.getId())
         .memberId(tagFollow.getMember().getId())
         .memberName(tagFollow.getMember().getName())
         .tagId(tagFollow.getTag().getTagId())

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/dto/TagFollowResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/dto/TagFollowResponse.java
@@ -1,0 +1,32 @@
+package com.onedrinktoday.backend.domain.tagFollow.dto;
+
+import com.onedrinktoday.backend.domain.tagFollow.entity.TagFollow;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TagFollowResponse {
+
+  private Long followId;
+  private Long memberId;
+  private String memberName;
+  private Long tagId;
+  private String tagName;
+
+  public static TagFollowResponse from(TagFollow tagFollow) {
+    return TagFollowResponse.builder()
+        .followId(tagFollow.getId())
+        .memberId(tagFollow.getMember().getId())
+        .memberName(tagFollow.getMember().getName())
+        .tagId(tagFollow.getTag().getTagId())
+        .tagName(tagFollow.getTag().getTagName())
+        .build();
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/entity/TagFollow.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/entity/TagFollow.java
@@ -1,0 +1,38 @@
+package com.onedrinktoday.backend.domain.tagFollow.entity;
+
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "tagFollow")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagFollow {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @ManyToOne
+  @JoinColumn(name = "tag_id")
+  private Tag tag;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/repository/TagFollowRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/repository/TagFollowRepository.java
@@ -1,0 +1,13 @@
+package com.onedrinktoday.backend.domain.tagFollow.repository;
+
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.tagFollow.entity.TagFollow;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagFollowRepository extends JpaRepository<TagFollow, Long> {
+
+  List<TagFollow> findByMember(Member member);
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/repository/TagFollowRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/repository/TagFollowRepository.java
@@ -1,6 +1,7 @@
 package com.onedrinktoday.backend.domain.tagFollow.repository;
 
 import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
 import com.onedrinktoday.backend.domain.tagFollow.entity.TagFollow;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface TagFollowRepository extends JpaRepository<TagFollow, Long> {
 
   List<TagFollow> findByMember(Member member);
+
+  boolean existsByMemberAndTag(Member member, Tag tag);
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/service/TagFollowService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/service/TagFollowService.java
@@ -1,0 +1,69 @@
+package com.onedrinktoday.backend.domain.tagFollow.service;
+
+import static com.onedrinktoday.backend.global.exception.ErrorCode.*;
+
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
+import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import com.onedrinktoday.backend.domain.tag.repository.TagRepository;
+import com.onedrinktoday.backend.domain.tagFollow.dto.TagFollowRequest;
+import com.onedrinktoday.backend.domain.tagFollow.dto.TagFollowResponse;
+import com.onedrinktoday.backend.domain.tagFollow.entity.TagFollow;
+import com.onedrinktoday.backend.domain.tagFollow.repository.TagFollowRepository;
+import com.onedrinktoday.backend.global.exception.CustomException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+
+public class TagFollowService {
+
+  private final MemberService memberService;
+  private final MemberRepository memberRepository;
+  private final TagFollowRepository tagFollowRepository;
+  private final TagRepository tagRepository;
+
+  public TagFollowResponse followTag(TagFollowRequest request) {
+
+    Member member = memberService.getMember();
+
+    Tag tag = tagRepository.findById(request.getTagId())
+        .orElseThrow(() -> new CustomException(TAG_NOT_FOUND));
+
+    TagFollow tagFollow = TagFollow.builder()
+        .member(member)
+        .tag(tag)
+        .build();
+
+    tagFollowRepository.save(tagFollow);
+    return TagFollowResponse.from(tagFollow);
+  }
+
+  public List<TagFollowResponse> getTagFollows(Long memberId) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+    List<TagFollow> tagFollows = tagFollowRepository.findByMember(member);
+
+    return tagFollows.stream()
+        .map(TagFollowResponse::from)
+        .toList();
+  }
+
+  public void deleteTagFollow(Long followId) {
+
+    Member member = memberService.getMember();
+
+    TagFollow tagFollow = tagFollowRepository.findById(followId)
+        .orElseThrow(() -> new CustomException(TAG_NOT_FOUND));
+
+    if (!tagFollow.getMember().equals(member)) {
+      throw new CustomException(ACCESS_DENIED);
+    }
+
+    tagFollowRepository.delete(tagFollow);
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/service/TagFollowService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/service/TagFollowService.java
@@ -3,7 +3,6 @@ package com.onedrinktoday.backend.domain.tagFollow.service;
 import static com.onedrinktoday.backend.global.exception.ErrorCode.*;
 
 import com.onedrinktoday.backend.domain.member.entity.Member;
-import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
 import com.onedrinktoday.backend.domain.tag.entity.Tag;
 import com.onedrinktoday.backend.domain.tag.repository.TagRepository;
@@ -22,7 +21,6 @@ import org.springframework.stereotype.Service;
 public class TagFollowService {
 
   private final MemberService memberService;
-  private final MemberRepository memberRepository;
   private final TagFollowRepository tagFollowRepository;
   private final TagRepository tagRepository;
 
@@ -46,9 +44,9 @@ public class TagFollowService {
     return TagFollowResponse.from(tagFollow);
   }
 
-  public List<TagFollowResponse> getTagFollows(Long memberId) {
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+  public List<TagFollowResponse> getTagFollows() {
+
+    Member member = memberService.getMember();
 
     List<TagFollow> tagFollows = tagFollowRepository.findByMember(member);
 

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/service/TagFollowService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/service/TagFollowService.java
@@ -33,6 +33,10 @@ public class TagFollowService {
     Tag tag = tagRepository.findById(request.getTagId())
         .orElseThrow(() -> new CustomException(TAG_NOT_FOUND));
 
+    if (tagFollowRepository.existsByMemberAndTag(member, tag)) {
+      throw new CustomException(ALREADY_FOLLOWING);
+    }
+
     TagFollow tagFollow = TagFollow.builder()
         .member(member)
         .tag(tag)

--- a/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
   COMMENT_NOT_FOUND("댓글을 찾을수 없습니다.", HttpStatus.NOT_FOUND),
   POST_NOT_FOUND("게시글을 찾을수 없습니다.", HttpStatus.NOT_FOUND),
   TAG_NOT_FOUND("태그를 찾을수 없습니다.", HttpStatus.NOT_FOUND),
+  ALREADY_FOLLOWING("이미 팔로우 중인 태그입니다.", HttpStatus.BAD_REQUEST),
   REGION_NOT_FOUND("지역을 찾을수 없습니다.", HttpStatus.NOT_FOUND),
   REGION_EXIST("이미 존재하는 지역명입니다.", HttpStatus.BAD_REQUEST),
   LOGIN_FAIL("이메일, 비밀번호를 확인해 주세요.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
   REGISTRATION_NOT_FOUND("특산주 등록 정보를 찾을수 없습니다.", HttpStatus.NOT_FOUND),
   COMMENT_NOT_FOUND("댓글을 찾을수 없습니다.", HttpStatus.NOT_FOUND),
   POST_NOT_FOUND("게시글을 찾을수 없습니다.", HttpStatus.NOT_FOUND),
+  TAG_NOT_FOUND("태그를 찾을수 없습니다.", HttpStatus.NOT_FOUND),
   REGION_NOT_FOUND("지역을 찾을수 없습니다.", HttpStatus.NOT_FOUND),
   REGION_EXIST("이미 존재하는 지역명입니다.", HttpStatus.BAD_REQUEST),
   LOGIN_FAIL("이메일, 비밀번호를 확인해 주세요.", HttpStatus.BAD_REQUEST),

--- a/src/test/java/com/onedrinktoday/backend/domain/tagFollow/controller/TagFollowControllerTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/tagFollow/controller/TagFollowControllerTest.java
@@ -1,0 +1,168 @@
+package com.onedrinktoday.backend.domain.tagFollow.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedrinktoday.backend.domain.tagFollow.dto.TagFollowRequest;
+import com.onedrinktoday.backend.domain.tagFollow.dto.TagFollowResponse;
+import com.onedrinktoday.backend.domain.tagFollow.service.TagFollowService;
+import com.onedrinktoday.backend.global.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static com.onedrinktoday.backend.global.exception.ErrorCode.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@WithMockUser
+@WebMvcTest(TagFollowController.class)
+public class TagFollowControllerTest {
+
+  @MockBean
+  private TagFollowService tagFollowService;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private TagFollowRequest tagFollowRequest;
+  private TagFollowResponse tagFollowResponse;
+
+  @BeforeEach
+  void setUp() {
+    tagFollowRequest = new TagFollowRequest();
+    tagFollowRequest.setTagId(1L);
+
+    tagFollowResponse = TagFollowResponse.builder()
+        .followId(1L)
+        .memberId(1L)
+        .memberName("John")
+        .tagId(1L)
+        .tagName("spicy")
+        .build();
+  }
+
+  @Test
+  @DisplayName("태그 팔로우 성공")
+  void successFollowTag() throws Exception {
+    //given
+    given(tagFollowService.followTag(any(TagFollowRequest.class))).willReturn(tagFollowResponse);
+
+    //when
+    //then
+    mockMvc.perform(post("/api/tags/follows")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(tagFollowRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.followId").value(tagFollowResponse.getFollowId()))
+        .andExpect(jsonPath("$.memberId").value(tagFollowResponse.getMemberId()))
+        .andExpect(jsonPath("$.memberName").value(tagFollowResponse.getMemberName()))
+        .andExpect(jsonPath("$.tagId").value(tagFollowResponse.getTagId()))
+        .andExpect(jsonPath("$.tagName").value(tagFollowResponse.getTagName()))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("태그 팔로우 실패 - 태그가 존재하지 않음")
+  void failFollowTag() throws Exception {
+    //given
+    given(tagFollowService.followTag(any(TagFollowRequest.class)))
+        .willThrow(new CustomException(TAG_NOT_FOUND));
+
+    //when
+    //then
+    mockMvc.perform(post("/api/tags/follows")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(tagFollowRequest)))
+        .andExpect(status().isNotFound())
+        .andExpect(content().string(TAG_NOT_FOUND.getMessage()))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("태그 팔로우 목록 조회 성공")
+  void successGetTagFollows() throws Exception {
+    //given
+    given(tagFollowService.getTagFollows(anyLong())).willReturn(List.of(tagFollowResponse));
+
+    //when
+    //then
+    mockMvc.perform(get("/api/members/1/tags/follows")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].followId").value(tagFollowResponse.getFollowId()))
+        .andExpect(jsonPath("$[0].memberId").value(tagFollowResponse.getMemberId()))
+        .andExpect(jsonPath("$[0].memberName").value(tagFollowResponse.getMemberName()))
+        .andExpect(jsonPath("$[0].tagId").value(tagFollowResponse.getTagId()))
+        .andExpect(jsonPath("$[0].tagName").value(tagFollowResponse.getTagName()))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("태그 팔로우 목록 조회 실패 - 회원을 찾을 수 없음")
+  void failGetTagFollows() throws Exception {
+    //given
+    given(tagFollowService.getTagFollows(anyLong())).willThrow(
+        new CustomException(MEMBER_NOT_FOUND));
+
+    //when
+    //then
+    mockMvc.perform(get("/api/members/1/tags/follows")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(content().string(MEMBER_NOT_FOUND.getMessage()))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("태그 팔로우 삭제 성공")
+  void successDeleteTagFollow() throws Exception {
+    //when
+    //then
+    mockMvc.perform(delete("/api/tags/follows/1")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().string("팔로우 태그가 삭제되었습니다."))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("태그 팔로우 삭제 실패 - 접근이 거부됨")
+  void failDeleteTagFollow() throws Exception {
+    //given
+    doThrow(new CustomException(ACCESS_DENIED)).when(tagFollowService).deleteTagFollow(anyLong());
+
+    //when
+    //then
+    mockMvc.perform(delete("/api/tags/follows/1")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden())
+        .andExpect(content().string(ACCESS_DENIED.getMessage()))
+        .andDo(print());
+  }
+}

--- a/src/test/java/com/onedrinktoday/backend/domain/tagFollow/controller/TagFollowControllerTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/tagFollow/controller/TagFollowControllerTest.java
@@ -53,7 +53,7 @@ public class TagFollowControllerTest {
     tagFollowRequest.setTagId(1L);
 
     tagFollowResponse = TagFollowResponse.builder()
-        .followId(1L)
+        .id(1L)
         .memberId(1L)
         .memberName("John")
         .tagId(1L)
@@ -74,7 +74,7 @@ public class TagFollowControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(tagFollowRequest)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.followId").value(tagFollowResponse.getFollowId()))
+        .andExpect(jsonPath("$.id").value(tagFollowResponse.getId()))
         .andExpect(jsonPath("$.memberId").value(tagFollowResponse.getMemberId()))
         .andExpect(jsonPath("$.memberName").value(tagFollowResponse.getMemberName()))
         .andExpect(jsonPath("$.tagId").value(tagFollowResponse.getTagId()))
@@ -104,15 +104,15 @@ public class TagFollowControllerTest {
   @DisplayName("태그 팔로우 목록 조회 성공")
   void successGetTagFollows() throws Exception {
     //given
-    given(tagFollowService.getTagFollows(anyLong())).willReturn(List.of(tagFollowResponse));
+    given(tagFollowService.getTagFollows()).willReturn(List.of(tagFollowResponse));
 
     //when
     //then
-    mockMvc.perform(get("/api/members/1/tags/follows")
+    mockMvc.perform(get("/api/members/tags/follows")
             .with(csrf())
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].followId").value(tagFollowResponse.getFollowId()))
+        .andExpect(jsonPath("$[0].id").value(tagFollowResponse.getId()))
         .andExpect(jsonPath("$[0].memberId").value(tagFollowResponse.getMemberId()))
         .andExpect(jsonPath("$[0].memberName").value(tagFollowResponse.getMemberName()))
         .andExpect(jsonPath("$[0].tagId").value(tagFollowResponse.getTagId()))
@@ -124,12 +124,11 @@ public class TagFollowControllerTest {
   @DisplayName("태그 팔로우 목록 조회 실패 - 회원을 찾을 수 없음")
   void failGetTagFollows() throws Exception {
     //given
-    given(tagFollowService.getTagFollows(anyLong())).willThrow(
-        new CustomException(MEMBER_NOT_FOUND));
+    given(tagFollowService.getTagFollows()).willThrow(new CustomException(MEMBER_NOT_FOUND));
 
     //when
     //then
-    mockMvc.perform(get("/api/members/1/tags/follows")
+    mockMvc.perform(get("/api/members/tags/follows")
             .with(csrf())
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound())

--- a/src/test/java/com/onedrinktoday/backend/domain/tagFollow/service/TagFollowServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/tagFollow/service/TagFollowServiceTest.java
@@ -1,0 +1,169 @@
+package com.onedrinktoday.backend.domain.tagFollow.service;
+
+import static com.onedrinktoday.backend.global.exception.ErrorCode.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
+import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import com.onedrinktoday.backend.domain.tag.repository.TagRepository;
+import com.onedrinktoday.backend.domain.tagFollow.dto.TagFollowRequest;
+import com.onedrinktoday.backend.domain.tagFollow.dto.TagFollowResponse;
+import com.onedrinktoday.backend.domain.tagFollow.entity.TagFollow;
+import com.onedrinktoday.backend.domain.tagFollow.repository.TagFollowRepository;
+import com.onedrinktoday.backend.global.exception.CustomException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TagFollowServiceTest {
+
+  @InjectMocks
+  private TagFollowService tagFollowService;
+
+  @Mock
+  private MemberService memberService;
+
+  @Mock
+  private TagRepository tagRepository;
+
+  @Mock
+  private TagFollowRepository tagFollowRepository;
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  private TagFollow tagFollow;
+  private Member member;
+  private Tag tag;
+  private TagFollowRequest tagFollowRequest;
+
+  @BeforeEach
+  void setUp() {
+    member = new Member();
+    member.setId(1L);
+    member.setName("John");
+
+    tag = new Tag();
+    tag.setTagId(1L);
+    tag.setTagName("spicy");
+
+    tagFollow = TagFollow.builder()
+        .id(1L)
+        .member(member)
+        .tag(tag)
+        .build();
+
+    tagFollowRequest = new TagFollowRequest();
+    tagFollowRequest.setTagId(1L);
+  }
+
+  @Test
+  @DisplayName("태그 팔로우 성공")
+  void successFollowTag() {
+    //given
+    when(memberService.getMember()).thenReturn(member);
+    when(tagRepository.findById(anyLong())).thenReturn(Optional.of(tag));
+    when(tagFollowRepository.save(any(TagFollow.class))).thenReturn(tagFollow);
+
+    //when
+    TagFollowResponse response = tagFollowService.followTag(tagFollowRequest);
+
+    //then
+    assertNotNull(response);
+    assertEquals(tagFollow.getMember().getId(), response.getMemberId());
+    assertEquals(tagFollow.getMember().getName(), response.getMemberName());
+    assertEquals(tagFollow.getTag().getTagId(), response.getTagId());
+    assertEquals(tagFollow.getTag().getTagName(), response.getTagName());
+  }
+
+  @Test
+  @DisplayName("태그 팔로우 실패 - 태그를 찾을 수 없음")
+  void failFollowTag() {
+    //given
+    when(memberService.getMember()).thenReturn(member);
+    when(tagRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    //when
+    CustomException thrown = assertThrows(CustomException.class,
+        () -> tagFollowService.followTag(tagFollowRequest));
+
+    //then
+    assertEquals(TAG_NOT_FOUND, thrown.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("팔로우한 태그 조회 성공")
+  void successGetTagFollows() {
+    //given
+    when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+    when(tagFollowRepository.findByMember(any(Member.class))).thenReturn(List.of(tagFollow));
+
+    //when
+    TagFollowResponse response = tagFollowService.getTagFollows(1L).get(0);
+
+    //then
+    assertEquals(tagFollow.getId(), response.getFollowId());
+    assertEquals(member.getId(), response.getMemberId());
+    assertEquals(member.getName(), response.getMemberName());
+    assertEquals(tag.getTagId(), response.getTagId());
+    assertEquals(tag.getTagName(), response.getTagName());
+  }
+
+  @Test
+  @DisplayName("팔로우한 태그 조회 실패 - 존재하지 않는 사용자 ID")
+  void failGetTagFollows() {
+    //given
+    when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+    //when
+    CustomException thrown = assertThrows(CustomException.class,
+        () -> tagFollowService.getTagFollows(1L));
+
+    //then
+    assertEquals(MEMBER_NOT_FOUND, thrown.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("팔로우한 태그 삭제 성공")
+  void successDeleteTagFollow() {
+    //given
+    when(memberService.getMember()).thenReturn(member);
+    when(tagFollowRepository.findById(anyLong())).thenReturn(Optional.of(tagFollow));
+
+    //when
+    tagFollowService.deleteTagFollow(1L);
+  }
+
+  @Test
+  @DisplayName("팔로우한 태그 삭제 실패 - 다른 사용자")
+  void failDeleteTagFollow() {
+    //given
+    Member otherMember = new Member();
+    otherMember.setId(2L);
+    otherMember.setName("Other Member");
+
+    when(memberService.getMember()).thenReturn(otherMember);
+    when(tagFollowRepository.findById(anyLong())).thenReturn(Optional.of(tagFollow));
+
+    //when
+    CustomException thrown = assertThrows(CustomException.class,
+        () -> tagFollowService.deleteTagFollow(1L));
+
+    //then
+    assertEquals(ACCESS_DENIED, thrown.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
- 태그 팔로우: 사용자가 태그를 팔로우할 수 있도록 followTag 메서드를 구현하였으며, 이미 팔로우 중인 경우에는 ALREADY_FOLLOWING 오류를 반환합니다.
- 태그 팔로우 목록 조회: 사용자가 자신의 팔로우 목록을 조회할 수 있도록 getTagFollows 메서드를 구현하였습니다.
- 태그 팔로우 취소: 사용자가 팔로우한 태그를 취소할 수 있도록 deleteTagFollow 메서드를 구현하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 