### PR TITLE
이메일 사전 중복 체크, 거주지 정보 삭제, 게시글 imageUrl 필드 추가

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -26,6 +27,12 @@ public class MemberController {
 
   private final MemberService memberService;
   private final JwtProvider jwtProvider;
+
+  @GetMapping("/members/email/{email}/validation")
+  public ResponseEntity<String> validateEmail(@PathVariable String email) {
+    memberService.validateEmail(email);
+    return ResponseEntity.ok().body("이메일 중복 확인 완료");
+  }
 
   @PostMapping("/members/signup")
   public ResponseEntity<MemberResponse> signUp(@Valid @RequestBody MemberRequest.SignUp request) {

--- a/src/main/java/com/onedrinktoday/backend/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/dto/MemberRequest.java
@@ -17,9 +17,6 @@ public class MemberRequest {
   @Builder
   public static class SignUp {
 
-    @NotNull(message = "지역 ID를 입력해주세요.")
-    private Long regionId;
-
     @Pattern(regexp = "^[a-zA-Z0-9가-힣_-]{2,7}$", message = "이름을 2~7글자 사이로 입력해주세요.")
     private String name;
 
@@ -36,8 +33,7 @@ public class MemberRequest {
     private List<DrinkType> favorDrinkType;
     private boolean alarmEnabled;
 
-    public SignUp(Long regionId, String name, String email, String password, Date birthDate, List<DrinkType> favorDrinkType, boolean alarmEnabled) {
-      this.regionId = regionId;
+    public SignUp(String name, String email, String password, Date birthDate, List<DrinkType> favorDrinkType, boolean alarmEnabled) {
       this.name = name;
       this.email = email;
       this.password = password;
@@ -67,21 +63,16 @@ public class MemberRequest {
   @Builder
   public static class UpdateInfo {
 
-    private Long regionId;
-
     @Pattern(regexp = "^[a-zA-Z0-9가-힣_-]{2,10}$", message = "이름을 2~10글자 사이로 입력해주세요.")
     private String name;
 
     private List<DrinkType> favorDrinkType;
     private boolean alarmEnabled;
-    private String imageUrl;
 
-    public UpdateInfo(Long regionId, String name, List<DrinkType> favorDrinkType, boolean alarmEnabled, String imageUrl) {
-      this.regionId = regionId;
+    public UpdateInfo(String name, List<DrinkType> favorDrinkType, boolean alarmEnabled) {
       this.name = name;
       this.favorDrinkType = favorDrinkType;
       this.alarmEnabled = alarmEnabled;
-      this.imageUrl = imageUrl;
     }
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/dto/MemberResponse.java
@@ -35,7 +35,7 @@ public class MemberResponse {
   public static MemberResponse from(Member member) {
     return MemberResponse.builder()
         .id(member.getId())
-        .placeName(member.getRegion().getPlaceName())
+        .placeName(member.getRegion() == null ? null : member.getRegion().getPlaceName())
         .name(member.getName())
         .email(member.getEmail())
         .birthDate(member.getBirthDate())

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
@@ -28,6 +28,7 @@ public class PostResponse {
   private String content;
   private Float rating;
   private List<TagDTO> tags;
+  private String imageUrl;
   private Integer viewCount;
   private Timestamp createdAt;
   private Timestamp updatedAt;
@@ -42,6 +43,7 @@ public class PostResponse {
         .content(post.getContent())
         .rating(post.getRating())
         .tags(tags.stream().map(TagDTO::from).collect(Collectors.toList()))
+        .imageUrl(post.getImageUrl())
         .viewCount(post.getViewCount())
         .createdAt(post.getCreatedAt())
         .updatedAt(post.getUpdatedAt())
@@ -58,6 +60,7 @@ public class PostResponse {
         .type(post.getType())
         .content(post.getContent())
         .rating(post.getRating())
+        .imageUrl(post.getImageUrl())
         .viewCount(post.getViewCount())
         .createdAt(post.getCreatedAt())
         .drink(DrinkResponse.from(post.getDrink()))

--- a/src/main/java/com/onedrinktoday/backend/domain/post/entity/Post.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/entity/Post.java
@@ -56,6 +56,9 @@ public class Post {
   @Column(name = "rating", nullable = true)
   private Float rating;
 
+  @Column(name = "image_url")
+  private String imageUrl;
+
   @Column(name = "view_count", nullable = true)
   private Integer viewCount;
 

--- a/src/test/java/com/onedrinktoday/backend/domain/member/controller/MemberRegistrationControllerTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/member/controller/MemberRegistrationControllerTest.java
@@ -72,7 +72,6 @@ public class MemberRegistrationControllerTest {
   @BeforeEach
   public void setUp() {
     signUpRequest = MemberRequest.SignUp.builder()
-        .regionId(1L)
         .name("JohnDoe")
         .email(VALID_EMAIL)
         .password(VALID_PASSWORD)
@@ -94,7 +93,7 @@ public class MemberRegistrationControllerTest {
         .build();
 
     updateInfo = new MemberRequest.UpdateInfo(
-        2L, "JohnDoeBa", List.of(DrinkType.BEER), false, "newImageUrl");
+        "JohnDoeBa", List.of(DrinkType.BEER), false);
 
     tokenDto = TokenDto.builder()
         .accessToken("accessToken")
@@ -131,7 +130,6 @@ public class MemberRegistrationControllerTest {
   public void failSignUp() throws Exception {
     //given
     MemberRequest.SignUp invalidRequest = MemberRequest.SignUp.builder()
-        .regionId(null)
         .name(null)
         .email(null)
         .password(null)
@@ -400,7 +398,6 @@ public class MemberRegistrationControllerTest {
         .role(Role.USER)
         .alarmEnabled(updateInfo.isAlarmEnabled())
         .createdAt(new Timestamp(System.currentTimeMillis()))
-        .imageUrl(updateInfo.getImageUrl())
         .build();
 
     given(memberService.updateMemberInfo(any(MemberRequest.UpdateInfo.class)))
@@ -416,7 +413,6 @@ public class MemberRegistrationControllerTest {
         .andExpect(jsonPath("$.name").value(updateInfo.getName()))
         .andExpect(jsonPath("$.favorDrinkType[0]").value(updateInfo.getFavorDrinkType().get(0).toString()))
         .andExpect(jsonPath("$.alarmEnabled").value(updateInfo.isAlarmEnabled()))
-        .andExpect(jsonPath("$.imageUrl").value(updateInfo.getImageUrl()))
         .andDo(print());
   }
 

--- a/src/test/java/com/onedrinktoday/backend/domain/member/service/MemberRigistrationServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/member/service/MemberRigistrationServiceTest.java
@@ -90,10 +90,10 @@ public class MemberRigistrationServiceTest {
     // favorDrinks 리스트 초기화
     favorDrinkTypes = Arrays.asList(DrinkType.SOJU, DrinkType.BEER);
 
-    signUpRequest = new SignUp(1L, "John", "john@google.com", "Password123!", new Date(),
+    signUpRequest = new SignUp("John", "john@google.com", "Password123!", new Date(),
         favorDrinkTypes, true);
     signInRequest = new SignIn("john@google.com", "Password123!");
-    updateInfo = new UpdateInfo(1L, "John", favorDrinkTypes, true, "new_image_url");
+    updateInfo = new UpdateInfo("John", favorDrinkTypes, true);
   }
 
   @Test
@@ -323,15 +323,10 @@ public class MemberRigistrationServiceTest {
         .imageUrl(member.getImageUrl())
         .build();
 
-    Region updateRegion = new Region();
-    updateRegion.setId(updateInfo.getRegionId());
-
     Member updatedMember = Member.builder()
-        .region(updateRegion)
         .name(updateInfo.getName())
         .favorDrinkType(updateInfo.getFavorDrinkType())
         .alarmEnabled(updateInfo.isAlarmEnabled())
-        .imageUrl(updateInfo.getImageUrl())
         .build();
 
     when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(existMember));
@@ -370,8 +365,8 @@ public class MemberRigistrationServiceTest {
         .imageUrl(member.getImageUrl())
         .build();
 
-    UpdateInfo wrongUpdateInfo = new UpdateInfo(101010L, updateInfo.getName(),
-        updateInfo.getFavorDrinkType(), updateInfo.isAlarmEnabled(), updateInfo.getImageUrl());
+    UpdateInfo wrongUpdateInfo = new UpdateInfo(updateInfo.getName(),
+        updateInfo.getFavorDrinkType(), updateInfo.isAlarmEnabled());
 
     //MemberDetail 사용하여 인증 정보 확인
     MemberDetail memberDetail = new MemberDetail(MemberResponse.from(existMember));


### PR DESCRIPTION
### 변경사항
- 이메일 중복 사전 체크 기능
- 가입 시 거주지 받지 않도록
- UpdateInfo: imageUrl 인자로 받지 않도록(파일로 전달받아 백에서 저장 및 url 생성)
- 게시글 imageUrl 필드 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 