### PR TITLE
feat: 5가지 타입의 알림 기능 구현

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/comment/service/CommentService.java
@@ -8,6 +8,7 @@ import com.onedrinktoday.backend.domain.comment.entity.Comment;
 import com.onedrinktoday.backend.domain.comment.repository.CommentRepository;
 import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.domain.notification.service.NotificationService;
 import com.onedrinktoday.backend.domain.post.entity.Post;
 import com.onedrinktoday.backend.domain.post.repository.PostRepository;
 import com.onedrinktoday.backend.global.exception.CustomException;
@@ -23,6 +24,7 @@ public class CommentService {
   private final CommentRepository commentRepository;
   private final PostRepository postRepository;
   private final MemberService memberService;
+  private final NotificationService notificationService;
 
   public CommentResponse createComment(CommentRequest commentRequest) {
 
@@ -39,6 +41,7 @@ public class CommentService {
         .build();
 
     commentRepository.save(comment);
+    notificationService.postCommentNotification(post.getId(), member.getName(), commentRequest.isAnonymous());
 
     return CommentResponse.from(comment);
   }

--- a/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
@@ -103,7 +103,7 @@ public class ManagerService {
 
       // 설정 파일에 정의된 것을 사용하여 postId를 추출
       return Long.parseLong(variables.get(postId));
-    } catch (Exception e) {
+    } catch (CustomException e) {
       throw new CustomException(LINK_NOT_FOUND);
     }
   }

--- a/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
@@ -1,15 +1,18 @@
 package com.onedrinktoday.backend.domain.manager.service;
 
+import static com.onedrinktoday.backend.global.exception.ErrorCode.*;
 import com.onedrinktoday.backend.domain.declaration.dto.DeclarationResponse;
 import com.onedrinktoday.backend.domain.declaration.entity.Declaration;
 import com.onedrinktoday.backend.domain.declaration.repository.DeclarationRepository;
 import com.onedrinktoday.backend.domain.drink.dto.DrinkResponse;
 import com.onedrinktoday.backend.domain.drink.entity.Drink;
 import com.onedrinktoday.backend.domain.drink.repository.DrinkRepository;
+import com.onedrinktoday.backend.domain.notification.service.NotificationService;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.post.repository.PostRepository;
 import com.onedrinktoday.backend.domain.registration.entity.Registration;
 import com.onedrinktoday.backend.domain.registration.repository.RegistrationRepository;
 import com.onedrinktoday.backend.global.exception.CustomException;
-import com.onedrinktoday.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,12 +24,14 @@ public class ManagerService {
   private final DrinkRepository drinkRepository;
   private final RegistrationRepository registrationRepository;
   private final DeclarationRepository declarationRepository;
+  private final PostRepository postRepository;
+  private final NotificationService notificationService;
 
   @Transactional
   public DrinkResponse approveRegistration(Long registId) {
 
     Registration registration = registrationRepository.findById(registId)
-        .orElseThrow(() -> new CustomException(ErrorCode.REGISTRATION_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(REGISTRATION_NOT_FOUND));
 
     registration.setApproved(true);
     registrationRepository.save(registration);
@@ -48,29 +53,45 @@ public class ManagerService {
   public void cancelRegistration(Long registId) {
 
     Registration registration = registrationRepository.findById(registId)
-        .orElseThrow(() -> new CustomException(ErrorCode.REGISTRATION_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(REGISTRATION_NOT_FOUND));
 
     registration.setApproved(false);
     registrationRepository.save(registration);
   }
 
   public DeclarationResponse approveDeclaration(Long declarationId) {
-
     Declaration declaration = declarationRepository.findById(declarationId)
-        .orElseThrow(() -> new CustomException(ErrorCode.DECLARATION_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(DECLARATION_NOT_FOUND));
+
+    Post post = postRepository.findById(postIdFromLink(declaration.getLink()))
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+    postRepository.delete(post);
+
+    notificationService.postDeclarationNotification(post, declaration);
 
     declaration.setApproved(true);
-
     return DeclarationResponse.from(declarationRepository.save(declaration));
   }
 
   public DeclarationResponse cancelDeclaration(Long declarationId) {
 
     Declaration declaration = declarationRepository.findById(declarationId)
-        .orElseThrow(() -> new CustomException(ErrorCode.DECLARATION_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(DECLARATION_NOT_FOUND));
 
     declaration.setApproved(false);
 
     return DeclarationResponse.from(declarationRepository.save(declaration));
+  }
+
+  //링크에서 게시글 ID를 확인하여 게시글를 조회
+  private Long postIdFromLink(String link) {
+    try {
+      String[] parts = link.split("/");
+
+      return Long.parseLong(parts[parts.length - 1]);
+    } catch (CustomException e) {
+      throw new CustomException(LINK_NOT_FOUND);
+    }
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
@@ -47,6 +47,10 @@ public class ManagerService {
         .imageUrl(registration.getImageUrl())
         .build();
 
+    notificationService.approveRegistrationNotification(
+        registration.getMember(), registration
+    );
+
     return DrinkResponse.from(drinkRepository.save(drink));
   }
 

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/controller/NotificationController.java
@@ -1,0 +1,27 @@
+package com.onedrinktoday.backend.domain.notification.controller;
+
+import com.onedrinktoday.backend.domain.notification.dto.NotificationResponse;
+import com.onedrinktoday.backend.domain.notification.service.NotificationService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  @GetMapping("/notifications")
+  public List<NotificationResponse> getRecentNotifications() {
+
+    return notificationService.getRecentNotifications()
+        .stream()
+        .map(NotificationResponse::from)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/controller/NotificationController.java
@@ -2,9 +2,11 @@ package com.onedrinktoday.backend.domain.notification.controller;
 
 import com.onedrinktoday.backend.domain.notification.dto.NotificationResponse;
 import com.onedrinktoday.backend.domain.notification.service.NotificationService;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,11 +19,10 @@ public class NotificationController {
   private final NotificationService notificationService;
 
   @GetMapping("/notifications")
-  public List<NotificationResponse> getRecentNotifications() {
+  public Page<NotificationResponse> getRecentNotifications(
+      @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-    return notificationService.getRecentNotifications()
-        .stream()
-        .map(NotificationResponse::from)
-        .collect(Collectors.toList());
+    return notificationService.getRecentNotifications(pageable)
+        .map(NotificationResponse::from);
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/controller/NotificationController.java
@@ -20,7 +20,7 @@ public class NotificationController {
 
   @GetMapping("/notifications")
   public Page<NotificationResponse> getRecentNotifications(
-      @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
     return notificationService.getRecentNotifications(pageable)
         .map(NotificationResponse::from);

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,32 @@
+package com.onedrinktoday.backend.domain.notification.dto;
+
+import com.onedrinktoday.backend.domain.notification.entity.Notification;
+import com.onedrinktoday.backend.global.type.NotificationType;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponse {
+
+  private Long id;
+  private Long postId;
+  private NotificationType type;
+  private String content;
+  private Timestamp createdAt;
+
+  public static NotificationResponse from(Notification notification) {
+    return NotificationResponse.builder()
+        .id(notification.getId())
+        .postId(notification.getPostId())
+        .type(notification.getType())
+        .content(notification.getContent())
+        .createdAt(notification.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/entity/Notification.java
@@ -1,0 +1,48 @@
+package com.onedrinktoday.backend.domain.notification.entity;
+
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.global.type.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Table(name = "notification")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Notification {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  private Long postId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationType type;
+
+  private String content;
+
+  @CreationTimestamp
+  private Timestamp createdAt;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.onedrinktoday.backend.domain.notification.repository;
+
+import com.onedrinktoday.backend.domain.notification.entity.Notification;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  List<Notification> findTop20ByMemberIdOrderByCreatedAtDesc(Long member);
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/repository/NotificationRepository.java
@@ -1,12 +1,13 @@
 package com.onedrinktoday.backend.domain.notification.repository;
 
 import com.onedrinktoday.backend.domain.notification.entity.Notification;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-  List<Notification> findTop20ByMemberIdOrderByCreatedAtDesc(Long member);
+  Page<Notification> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
@@ -19,6 +19,8 @@ import com.onedrinktoday.backend.global.exception.CustomException;
 import com.onedrinktoday.backend.global.type.NotificationType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -43,9 +45,9 @@ public class NotificationService {
     notificationRepository.save(notification);
   }
 
-  public List<Notification> getRecentNotifications() {
-    Long member = memberService.getMember().getId();
-    return notificationRepository.findTop20ByMemberIdOrderByCreatedAtDesc(member);
+  public Page<Notification> getRecentNotifications(Pageable pageable) {
+    Long memberId = memberService.getMember().getId();
+    return notificationRepository.findByMemberId(memberId, pageable);
   }
 
   public void postCommentNotification(Long postId, String memberName, boolean isAnonymous) {

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -57,6 +58,7 @@ public class NotificationService {
     createNotification(post.getMember(), postId, COMMENT, content);
   }
 
+  @Async
   public void tagFollowPostNotification(Long postId, List<Tag> tags) {
     Post post = postRepository.findById(postId)
         .orElseThrow(() -> new CustomException(POST_NOT_FOUND));

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
@@ -86,7 +86,7 @@ public class NotificationService {
         declaration.getMember(),
         null,
         NotificationType.DECLARATION,
-        "신고된 게시글이 승인되어 삭제되었습니다."
+        "신고된 게시글이 승인되었습니다."
     );
   }
 

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
@@ -10,7 +10,6 @@ import com.onedrinktoday.backend.domain.notification.entity.Notification;
 import com.onedrinktoday.backend.domain.notification.repository.NotificationRepository;
 import com.onedrinktoday.backend.domain.post.entity.Post;
 import com.onedrinktoday.backend.domain.post.repository.PostRepository;
-import com.onedrinktoday.backend.domain.postTag.repository.PostTagRepository;
 import com.onedrinktoday.backend.domain.registration.entity.Registration;
 import com.onedrinktoday.backend.domain.tag.entity.Tag;
 import com.onedrinktoday.backend.domain.tagFollow.entity.TagFollow;
@@ -31,7 +30,6 @@ public class NotificationService {
   private final MemberService memberService;
   private final PostRepository postRepository;
   private final TagFollowRepository tagFollowRepository;
-  private final PostTagRepository postTagRepository;
 
   public void createNotification(Member member, Long postId, NotificationType type,
       String content) {
@@ -59,11 +57,9 @@ public class NotificationService {
     createNotification(post.getMember(), postId, COMMENT, content);
   }
 
-  public void tagFollowPostNotification(Long postId) {
+  public void tagFollowPostNotification(Long postId, List<Tag> tags) {
     Post post = postRepository.findById(postId)
         .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
-
-    List<Tag> tags = postTagRepository.findTagsByPostId(postId);
 
     for (Tag tag : tags) {
       List<TagFollow> tagFollows = tagFollowRepository.findByTag(tag);

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
@@ -1,0 +1,103 @@
+package com.onedrinktoday.backend.domain.notification.service;
+
+import static com.onedrinktoday.backend.global.exception.ErrorCode.*;
+import static com.onedrinktoday.backend.global.type.NotificationType.*;
+
+import com.onedrinktoday.backend.domain.declaration.entity.Declaration;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.domain.notification.entity.Notification;
+import com.onedrinktoday.backend.domain.notification.repository.NotificationRepository;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.post.repository.PostRepository;
+import com.onedrinktoday.backend.domain.postTag.repository.PostTagRepository;
+import com.onedrinktoday.backend.domain.registration.entity.Registration;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import com.onedrinktoday.backend.domain.tagFollow.entity.TagFollow;
+import com.onedrinktoday.backend.domain.tagFollow.repository.TagFollowRepository;
+import com.onedrinktoday.backend.global.exception.CustomException;
+import com.onedrinktoday.backend.global.type.NotificationType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final MemberService memberService;
+  private final PostRepository postRepository;
+  private final TagFollowRepository tagFollowRepository;
+  private final PostTagRepository postTagRepository;
+
+  public void createNotification(Member member, Long postId, NotificationType type,
+      String content) {
+    Notification notification = Notification.builder()
+        .member(member)
+        .postId(postId)
+        .type(type)
+        .content(content)
+        .build();
+
+    notificationRepository.save(notification);
+  }
+
+  public List<Notification> getRecentNotifications() {
+    Long member = memberService.getMember().getId();
+    return notificationRepository.findTop20ByMemberIdOrderByCreatedAtDesc(member);
+  }
+
+  public void postCommentNotification(Long postId, String memberName, boolean isAnonymous) {
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+    String content = isAnonymous ? "게시글에 댓글이 달렸습니다." : memberName + "님이 댓글을 달았습니다.";
+
+    createNotification(post.getMember(), postId, COMMENT, content);
+  }
+
+  public void tagFollowPostNotification(Long postId) {
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+    List<Tag> tags = postTagRepository.findTagsByPostId(postId);
+
+    for (Tag tag : tags) {
+      List<TagFollow> tagFollows = tagFollowRepository.findByTag(tag);
+      for (TagFollow tagFollow : tagFollows) {
+        if (!tagFollow.getMember().equals(post.getMember())) {
+          createNotification(tagFollow.getMember(), postId, FOLLOW,
+              "새로운 게시글이 " + tag.getTagName() + " 태그와 작성되었습니다.");
+        }
+      }
+    }
+  }
+
+  public void postDeclarationNotification(Post post, Declaration declaration) {
+    createNotification(
+        post.getMember(),
+        post.getId(),
+        NotificationType.REMOVED,
+        "게시글이 신고되어 삭제되었습니다."
+    );
+
+    createNotification(
+        declaration.getMember(),
+        null,
+        NotificationType.DECLARATION,
+        "신고된 게시글이 승인되어 삭제되었습니다."
+    );
+  }
+
+  public void approveRegistrationNotification(Member member, Registration registration) {
+    String message = "신청된 " + registration.getDrinkName() + " 특산주가 승인되었습니다.";
+
+    createNotification(
+        member,
+        registration.getId(),
+        NotificationType.REGISTRATION,
+        message
+    );
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -6,6 +6,7 @@ import com.onedrinktoday.backend.domain.drink.repository.DrinkRepository;
 import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.domain.notification.service.NotificationService;
 import com.onedrinktoday.backend.domain.post.dto.PostRequest;
 import com.onedrinktoday.backend.domain.post.dto.PostResponse;
 import com.onedrinktoday.backend.domain.post.entity.Post;
@@ -40,6 +41,7 @@ public class PostService {
   private final PostTagRepository postTagRepository;
   private final CacheManager cacheManager;
   private final CacheService cacheService;
+  private final NotificationService notificationService;
 
   // 게시글 생성 및 저장
   @CacheEvict(key = "#postRequest.drinkId", value = "avg-rating")
@@ -66,6 +68,7 @@ public class PostService {
     // 태그 저장 및 PostTag 연결
     List<Tag> tags = saveTags(postRequest.getTag(), post);
 
+    notificationService.tagFollowPostNotification(post.getId());
     return PostResponse.of(post, tags);
   }
 

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -68,7 +68,7 @@ public class PostService {
     // 태그 저장 및 PostTag 연결
     List<Tag> tags = saveTags(postRequest.getTag(), post);
 
-    notificationService.tagFollowPostNotification(post.getId());
+    notificationService.tagFollowPostNotification(post.getId(), tags);
     return PostResponse.of(post, tags);
   }
 

--- a/src/main/java/com/onedrinktoday/backend/domain/registration/service/RegistrationService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/registration/service/RegistrationService.java
@@ -2,7 +2,6 @@ package com.onedrinktoday.backend.domain.registration.service;
 
 import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
-import com.onedrinktoday.backend.domain.notification.service.NotificationService;
 import com.onedrinktoday.backend.domain.region.entity.Region;
 import com.onedrinktoday.backend.domain.region.repository.RegionRepository;
 import com.onedrinktoday.backend.domain.registration.dto.RegistrationRequest;
@@ -23,7 +22,6 @@ public class RegistrationService {
   private final RegistrationRepository registrationRepository;
   private final MemberService memberService;
   private final RegionRepository regionRepository;
-  private final NotificationService notificationService;
 
   public RegistrationResponse register(RegistrationRequest request) {
 
@@ -37,14 +35,7 @@ public class RegistrationService {
     registration.setMember(member);
     registration.setRegion(region);
 
-    Registration savedRegistration = registrationRepository.save(registration);
-
-    notificationService.approveRegistrationNotification(
-        registration.getMember(),
-        savedRegistration
-    );
-
-    return RegistrationResponse.from(savedRegistration);
+    return RegistrationResponse.from(registrationRepository.save(registration));
   }
 
   public Page<RegistrationResponse> getRegistrations(Pageable pageable) {

--- a/src/main/java/com/onedrinktoday/backend/domain/registration/service/RegistrationService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/registration/service/RegistrationService.java
@@ -2,6 +2,7 @@ package com.onedrinktoday.backend.domain.registration.service;
 
 import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.domain.notification.service.NotificationService;
 import com.onedrinktoday.backend.domain.region.entity.Region;
 import com.onedrinktoday.backend.domain.region.repository.RegionRepository;
 import com.onedrinktoday.backend.domain.registration.dto.RegistrationRequest;
@@ -22,6 +23,7 @@ public class RegistrationService {
   private final RegistrationRepository registrationRepository;
   private final MemberService memberService;
   private final RegionRepository regionRepository;
+  private final NotificationService notificationService;
 
   public RegistrationResponse register(RegistrationRequest request) {
 
@@ -35,7 +37,14 @@ public class RegistrationService {
     registration.setMember(member);
     registration.setRegion(region);
 
-    return RegistrationResponse.from(registrationRepository.save(registration));
+    Registration savedRegistration = registrationRepository.save(registration);
+
+    notificationService.approveRegistrationNotification(
+        registration.getMember(),
+        savedRegistration
+    );
+
+    return RegistrationResponse.from(savedRegistration);
   }
 
   public Page<RegistrationResponse> getRegistrations(Pageable pageable) {

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/repository/TagFollowRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/repository/TagFollowRepository.java
@@ -13,4 +13,6 @@ public interface TagFollowRepository extends JpaRepository<TagFollow, Long> {
   List<TagFollow> findByMember(Member member);
 
   boolean existsByMemberAndTag(Member member, Tag tag);
+
+  List<TagFollow> findByTag(Tag tag);
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/service/TagFollowService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/service/TagFollowService.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-
 public class TagFollowService {
 
   private final MemberService memberService;

--- a/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
   TOKEN_EXPIRED("토큰이 유효 기간이 지나서 만료되었습니다.", HttpStatus.UNAUTHORIZED),
   TOKEN_NOT_MATCH("Refresh Token 값이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
   INVALID_REFRESH_TOKEN("리프레시 토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
-  ACCESS_DENIED("접근이 거부되었습니다.", HttpStatus.FORBIDDEN);
+  ACCESS_DENIED("접근이 거부되었습니다.", HttpStatus.FORBIDDEN),
+  LINK_NOT_FOUND("링크를 찾을 수가 없습니다.", HttpStatus.NOT_FOUND);
 
   private final String message;
   private final HttpStatus status;

--- a/src/main/java/com/onedrinktoday/backend/global/type/NotificationType.java
+++ b/src/main/java/com/onedrinktoday/backend/global/type/NotificationType.java
@@ -1,0 +1,9 @@
+package com.onedrinktoday.backend.global.type;
+
+public enum NotificationType {
+  FOLLOW,
+  COMMENT,
+  DECLARATION,
+  REGISTRATION,
+  REMOVED
+}


### PR DESCRIPTION
### 변경사항
- FOLLOW
  - 사용자가 팔로우 한 태그를 사용해서 다른 사용자가 게시글을 업로드하면 알림을 생성합니다.
  - 알림 생성 시 postId는 팔로우 한 태그의 게시글 ID가 반환됩니다.
- COMMENT
  - 게시글에 댓글이 달릴 때 알림을 생성합니다.
  - 댓글 작성자가 익명인 경우와 아닐 경우에 따라 알림 메시지가 다르게 설정됩니다.
  - 알림의 postId는 댓글이 달린 게시글 ID를 반환합니다.
- REGISTRATION
  - 특산주 신청이 승인되었을 때, 신청자에게 승인 알림을 생성합니다.
  - 알림 생성 시 postId는 특산주 신청 ID가 반환됩니다.
- DECLARATION, REMOVED
  - 게시글이 신고되어 매니저에 의해 삭제된 경우, 게시글 작성자와 신고자에게 알림을 생성합니다.
  - 게시글 작성자에게는 "게시글이 신고되어 삭제되었습니다."
  - 신고자에게는 "신고한 게시글이 승인되어 삭제되었습니다."
  - 신고가 승인된 게시글은 삭제되어 postId는 null이 됩니다.
- 알림 조회 기준
  - 최신 알람 기준 20개씩 항목을 반환하도록 설정


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 
  - 2명의 사용자와 매니저의 3개의 역할을 위해 3번 회원가입하고 로그인을 진행하여 API테스트를 진행하였습니다.
    - 다른 사용자가 팔로우한 태그 게시글 업로드와 특산주 요청 역할 회원
    - 댓글 작성, 태그 팔로우와 게시글 신고 역할 회원
    - 매니저 역할 회원 