### PR TITLE
refactor: 게시글 미 기능 구현 및 리팩토링, 테스트 코드 구현

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/drink/dto/DrinkResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/drink/dto/DrinkResponse.java
@@ -23,7 +23,7 @@ public class DrinkResponse {
   private Integer cost;
 
   @Setter
-  private Float averageRating;
+  private Double averageRating;
   private String description;
   private String imageUrl;
   private LocalDateTime createdAt;

--- a/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
@@ -82,6 +82,7 @@ public class ManagerService {
     notificationService.postDeclarationNotification(post, declaration);
 
     declaration.setApproved(true);
+
     return DeclarationResponse.from(declarationRepository.save(declaration));
   }
 

--- a/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/controller/PostController.java
@@ -32,9 +32,10 @@ public class PostController {
 
   @GetMapping("/posts")
   public ResponseEntity<Page<PostResponse>> getAllPosts(@RequestParam(defaultValue = "0") int page,
-                                                        @RequestParam(defaultValue = "10") int size) {
+                                                        @RequestParam(defaultValue = "10") int size,
+                                                        @RequestParam(defaultValue = "createdAt") String sortBy) {
     Pageable pageable = PageRequest.of(page, size);
-    Page<PostResponse> posts = postService.getAllPosts(pageable);
+    Page<PostResponse> posts = postService.getAllPosts(pageable, sortBy);
     return ResponseEntity.ok(posts);
   }
 

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostRequest.java
@@ -14,11 +14,17 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PostRequest {
   private Long drinkId;
+
   private Long memberId;
+
   private Type type;
+
   @Size(min = 10, max = 3000)
   private String content;
+
   private Float rating;
+
   private List<String> tag;
 
+  private String imageUrl;
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
@@ -34,6 +34,8 @@ public class PostResponse {
   private LocalDateTime updatedAt;
 
   public static PostResponse of(Post post, List<Tag> tags) {
+
+    String imageUrl = post.getImageUrl() != null ? post.getImageUrl() : post.getDrink().getImageUrl();
     return PostResponse.builder()
         .id(post.getId())
         .memberId(post.getMember().getId())
@@ -43,7 +45,7 @@ public class PostResponse {
         .content(post.getContent())
         .rating(post.getRating())
         .tags(tags.stream().map(TagDTO::from).collect(Collectors.toList()))
-        .imageUrl(post.getImageUrl())
+        .imageUrl(imageUrl)
         .viewCount(post.getViewCount())
         .createdAt(post.getCreatedAt())
         .updatedAt(post.getUpdatedAt())

--- a/src/main/java/com/onedrinktoday/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/repository/PostRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
   @Query(value = "select AVG(rating) from post where drink_id = :drinkId", nativeQuery = true)
-  Float getAverageRating(Long drinkId);
+  Double getAverageRating(Long drinkId);
 
   // 최신순으로 정렬
   Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);

--- a/src/main/java/com/onedrinktoday/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/repository/PostRepository.java
@@ -1,6 +1,8 @@
 package com.onedrinktoday.backend.domain.post.repository;
 
 import com.onedrinktoday.backend.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,4 +11,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
   @Query(value = "select AVG(rating) from post where drink_id = :drinkId", nativeQuery = true)
   Float getAverageRating(Long drinkId);
 
+  // 최신순으로 정렬
+  Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+  // 조회수 순으로 정렬
+  Page<Post> findAllByOrderByViewCountDesc(Pageable pageable);
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -52,6 +52,9 @@ public class PostService {
     Drink drink = drinkRepository.findById(postRequest.getDrinkId())
         .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 특산주입니다."));
 
+    // 이미지 우선순위 설정 - 1순위 : 게시글 업로드 이미지, 2순위 : 특산주 등록 이미지
+    String imageUrl = postRequest.getImageUrl() != null ? postRequest.getImageUrl() : drink.getImageUrl();
+
     // 게시글 엔티티 생성
     Post post = Post.builder()
         .member(member)
@@ -60,6 +63,7 @@ public class PostService {
         .content(postRequest.getContent())
         .rating(postRequest.getRating())
         .viewCount(0)  // 초기 조회수
+        .imageUrl(imageUrl)
         .build();
 
     // 게시글 저장
@@ -183,6 +187,10 @@ public class PostService {
           .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
       post.setMember(member);
     }
+
+    // 이미지 수정: 1순위 : 게시글 업로드 이미지, 2순위 : 특산주 등록 이미지
+    String imageUrl = postRequest.getImageUrl() != null ? postRequest.getImageUrl() : post.getDrink().getImageUrl();
+    post.setImageUrl(imageUrl);
 
     postRepository.save(post);
 

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -124,10 +124,18 @@ public class PostService {
 
     PostResponse postResponse = PostResponse.of(post, tags);
 
-    DrinkResponse drinkResponse = DrinkResponse.from(post.getDrink());
-    drinkResponse.setAverageRating(cacheService.getAverageRating(post.getDrink().getId()));
+    // CacheService에서 Double 타입의 평균 평점 가져오기
+    Double averageRating = cacheService.getAverageRating(post.getDrink().getId());
 
-    postResponse.setDrink(drinkResponse);
+    if (averageRating != null) {
+      // 소수점 둘째 자리까지 평균 평점 조회
+      String formattedRating = String.format("%.2f", averageRating);
+      Double formattedAverageRating = Double.parseDouble(formattedRating);
+
+      DrinkResponse drinkResponse = DrinkResponse.from(post.getDrink());
+      drinkResponse.setAverageRating(formattedAverageRating);
+      postResponse.setDrink(drinkResponse);
+    }
 
     return postResponse;
   }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -34,11 +34,11 @@ import org.springframework.stereotype.Service;
 public class PostService {
 
   private final PostRepository postRepository;
-  private final MemberRepository memberRepository;
-  private final MemberService memberService;
-  private final DrinkRepository drinkRepository;
-  private final TagRepository tagRepository;
   private final PostTagRepository postTagRepository;
+  private final TagRepository tagRepository;
+  private final MemberRepository memberRepository;
+  private final DrinkRepository drinkRepository;
+  private final MemberService memberService;
   private final CacheManager cacheManager;
   private final CacheService cacheService;
   private final NotificationService notificationService;
@@ -95,8 +95,14 @@ public class PostService {
   }
 
   // 전체 게시글 조회
-  public Page<PostResponse> getAllPosts(Pageable pageable) {
-    Page<Post> posts = postRepository.findAll(pageable);
+  public Page<PostResponse> getAllPosts(Pageable pageable, String sortBy) {
+    Page<Post> posts;
+
+    if("viewCount".equals(sortBy)) {
+      posts = postRepository.findAllByOrderByViewCountDesc(pageable); // 조회수 정렬
+    } else {
+      posts = postRepository.findAllByOrderByCreatedAtDesc(pageable); // 최신순 정렬
+    }
 
     return posts.map(post -> {
       List<Tag> tags = postTagRepository.findTagsByPostId(post.getId());

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -104,6 +104,11 @@ public class PostService {
       posts = postRepository.findAllByOrderByCreatedAtDesc(pageable); // 최신순 정렬
     }
 
+    // posts가 null이 아닌지 확인
+    if (posts == null || posts.isEmpty()) {
+      return Page.empty(pageable);  // 빈 페이지 반환
+    }
+
     return posts.map(post -> {
       List<Tag> tags = postTagRepository.findTagsByPostId(post.getId());
       return PostResponse.of(post, tags);

--- a/src/main/java/com/onedrinktoday/backend/domain/postTag/entity/PostTag.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/postTag/entity/PostTag.java
@@ -37,4 +37,10 @@ public class PostTag {
   @ManyToOne
   @JoinColumn(name = "tag_id", nullable = false)
   private Tag tag;
+
+  // Post와 Tag를 받는 생성자 추가
+  public PostTag(Post post, Tag tag) {
+    this.post = post;
+    this.tag = tag;
+  }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/registration/service/RegistrationService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/registration/service/RegistrationService.java
@@ -2,6 +2,7 @@ package com.onedrinktoday.backend.domain.registration.service;
 
 import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.domain.notification.service.NotificationService;
 import com.onedrinktoday.backend.domain.region.entity.Region;
 import com.onedrinktoday.backend.domain.region.repository.RegionRepository;
 import com.onedrinktoday.backend.domain.registration.dto.RegistrationRequest;
@@ -22,6 +23,7 @@ public class RegistrationService {
   private final RegistrationRepository registrationRepository;
   private final MemberService memberService;
   private final RegionRepository regionRepository;
+  private final NotificationService notificationService;
 
   public RegistrationResponse register(RegistrationRequest request) {
 
@@ -35,7 +37,14 @@ public class RegistrationService {
     registration.setMember(member);
     registration.setRegion(region);
 
-    return RegistrationResponse.from(registrationRepository.save(registration));
+    Registration savedRegistration = registrationRepository.save(registration);
+
+    notificationService.approveRegistrationNotification(
+        registration.getMember(),
+        savedRegistration
+    );
+
+    return RegistrationResponse.from(savedRegistration);
   }
 
   public Page<RegistrationResponse> getRegistrations(Pageable pageable) {

--- a/src/main/java/com/onedrinktoday/backend/global/cache/CacheService.java
+++ b/src/main/java/com/onedrinktoday/backend/global/cache/CacheService.java
@@ -12,7 +12,7 @@ public class CacheService {
   private final PostRepository postRepository;
 
   @Cacheable(key = "#drinkId", value = "avg-rating")
-  public Float getAverageRating(Long drinkId) {
+  public Double getAverageRating(Long drinkId) {
     return postRepository.getAverageRating(drinkId);
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/onedrinktoday/backend/global/exception/CustomExceptionHandler.java
@@ -1,7 +1,10 @@
 package com.onedrinktoday.backend.global.exception;
 
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -24,5 +27,14 @@ public class CustomExceptionHandler {
         .stream().map(DefaultMessageSourceResolvable::getDefaultMessage).toList().get(0);
 
     return ResponseEntity.badRequest().body(errorMessage);
+  }
+
+  // IllegalArgumentException 처리: 404 반환
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException e) {
+    Map<String, String> response = new HashMap<>();
+    response.put("error", e.getMessage());
+
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 }

--- a/src/test/java/com/onedrinktoday/backend/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,195 @@
+package com.onedrinktoday.backend.domain.post.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedrinktoday.backend.domain.post.dto.PostRequest;
+import com.onedrinktoday.backend.domain.post.dto.PostResponse;
+import com.onedrinktoday.backend.domain.post.service.PostService;
+import com.onedrinktoday.backend.domain.tag.dto.TagDTO;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+
+@WebMvcTest(controllers = PostController.class, excludeAutoConfiguration = {SecurityAutoConfiguration.class})
+public class PostControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private PostService postService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private PostRequest postRequest;
+  private PostResponse postResponse;
+
+  @BeforeEach
+  void setUp() {
+    postRequest = new PostRequest();
+    postRequest.setDrinkId(1L);
+    postRequest.setContent("맛있는 막걸리입니다!");
+    postRequest.setRating(4.5F);
+    postRequest.setTag(Arrays.asList("달콤", "시원"));
+
+    TagDTO tag1 = new TagDTO();
+    tag1.setTagName("달콤");
+
+    TagDTO tag2 = new TagDTO();
+    tag2.setTagName("시원");
+
+    List<TagDTO> tagDTOList = Arrays.asList(tag1, tag2);
+    postResponse = new PostResponse();
+    postResponse.setContent("맛있는 막걸리입니다!");
+    postResponse.setRating(4.5F);
+    postResponse.setTags(tagDTOList);
+  }
+
+  @Test
+  @DisplayName("게시글 생성 성공 테스트")
+  void successCreatePost() throws Exception {
+    given(postService.createPost(any(PostRequest.class))).willReturn(postResponse);
+
+    mockMvc.perform(post("/api/posts")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(postRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").value(postRequest.getContent()))
+        .andExpect(jsonPath("$.rating").value(postRequest.getRating()))
+        .andExpect(jsonPath("$.tags[0].tagName").value("달콤"))
+        .andExpect(jsonPath("$.tags[1].tagName").value("시원"));
+  }
+
+  // 성공 테스트
+  @Test
+  @DisplayName("게시글 조회 성공 테스트")
+  void successGetPostById() throws Exception {
+    given(postService.getPostById(1L)).willReturn(postResponse);
+
+    mockMvc.perform(get("/api/posts/{postId}", 1L))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").value(postResponse.getContent()))
+        .andExpect(jsonPath("$.rating").value(postResponse.getRating()))
+        .andExpect(jsonPath("$.tags[0].tagName").value("달콤"))
+        .andExpect(jsonPath("$.tags[1].tagName").value("시원"));
+  }
+
+  @Test
+  @DisplayName("게시글 조회 실패 테스트 - 존재하지 않는 게시글")
+  void failNotFoundGetPostById() throws Exception {
+    given(postService.getPostById(999L))
+        .willThrow(new IllegalArgumentException("해당 게시글을 찾을 수 없습니다."));
+
+    mockMvc.perform(get("/api/posts/{postId}", 999L))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("해당 게시글을 찾을 수 없습니다."));
+  }
+
+  @Test
+  @DisplayName("게시글 리스트 조회 성공 테스트")
+  void successGetAllPosts() throws Exception {
+    Page<PostResponse> postsPage = new PageImpl<>(Arrays.asList(postResponse), PageRequest.of(0, 10), 1);
+    given(postService.getAllPosts(any(PageRequest.class), eq("createdAt"))).willReturn(postsPage);
+
+    mockMvc.perform(get("/api/posts?page=0&size=10&sortBy=createdAt"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].content").value(postResponse.getContent()))
+        .andExpect(jsonPath("$.content[0].tags[0].tagName").value("달콤"))
+        .andExpect(jsonPath("$.content[0].tags[1].tagName").value("시원"));
+  }
+
+  @Test
+  @DisplayName("게시글 수정 성공 테스트")
+  void successUpdatePostById() throws Exception {
+    PostRequest updateRequest = new PostRequest();
+    updateRequest.setDrinkId(1L);
+    updateRequest.setContent("맛없는 막걸리입니다!");
+    updateRequest.setRating(2.0F);
+    updateRequest.setTag(Arrays.asList("씁쓸", "새콤"));
+
+    TagDTO tag3 = new TagDTO();
+    tag3.setTagName("씁쓸");
+
+    TagDTO tag4 = new TagDTO();
+    tag4.setTagName("새콤");
+
+    List<TagDTO> updatedTags = Arrays.asList(tag3, tag4);
+    PostResponse updatedResponse = new PostResponse();
+    updatedResponse.setContent("맛없는 막걸리입니다!");
+    updatedResponse.setRating(2.0F);
+    updatedResponse.setTags(updatedTags);
+
+    given(postService.updatePost(eq(1L), any(PostRequest.class))).willReturn(updatedResponse);
+
+    mockMvc.perform(put("/api/posts/{postId}", 1L)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").value("맛없는 막걸리입니다!"))
+        .andExpect(jsonPath("$.tags[0].tagName").value("씁쓸"))
+        .andExpect(jsonPath("$.tags[1].tagName").value("새콤"));
+  }
+
+  @Test
+  @DisplayName("게시글 수정 실패 테스트 - 존재하지 않는 게시글")
+  void failNotFoundUpdatePostById() throws Exception {
+    PostRequest updateRequest = new PostRequest();
+    updateRequest.setDrinkId(1L);
+    updateRequest.setContent("맛없는 막걸리입니다!");
+    updateRequest.setRating(2.0F);
+    updateRequest.setTag(Arrays.asList("씁쓸", "새콤"));
+
+    given(postService.updatePost(eq(999L), any(PostRequest.class)))
+        .willThrow(new IllegalArgumentException("해당 게시글을 찾을 수 없습니다."));
+
+    mockMvc.perform(put("/api/posts/{postId}", 999L)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("해당 게시글을 찾을 수 없습니다."));
+  }
+
+  @Test
+  @DisplayName("게시글 삭제 성공 테스트")
+  void successDeletePostById() throws Exception {
+    doNothing().when(postService).deletePostById(1L);
+
+    mockMvc.perform(delete("/api/posts/{postId}", 1L))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("게시글 삭제 실패 테스트 - 존재하지 않는 게시글")
+  void failNotFoundDeletePostById() throws Exception {
+    doThrow(new IllegalArgumentException("해당 게시글을 찾을 수 없습니다."))
+        .when(postService).deletePostById(999L);
+
+    mockMvc.perform(delete("/api/posts/{postId}", 999L))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("해당 게시글을 찾을 수 없습니다."));
+  }
+}

--- a/src/test/java/com/onedrinktoday/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/post/service/PostServiceTest.java
@@ -98,7 +98,7 @@ public class PostServiceTest {
 
   @Test
   @DisplayName("게시글 생성 성공 테스트")
-  void createPostSuccess() {
+  void successCreatePost() {
     // Given
     given(memberService.getMember()).willReturn(member);
     given(drinkRepository.findById(1L)).willReturn(Optional.of(drink));
@@ -128,7 +128,7 @@ public class PostServiceTest {
 
   @Test
   @DisplayName("게시글 생성 실패 테스트 - Drink ID 없음")
-  void createPostFailNoDrinkId() {
+  void failNoDrinkIdCreatePost() {
     // Given
     postRequest.setDrinkId(999L); // 존재하지 않는 Drink ID
     given(drinkRepository.findById(999L)).willReturn(Optional.empty());
@@ -139,7 +139,7 @@ public class PostServiceTest {
 
   @Test
   @DisplayName("게시글 조회 성공 테스트")
-  void getPostByIdSuccess() {
+  void successGetPostById() {
     // Given
     given(postRepository.findById(1L)).willReturn(Optional.of(post));
     given(postTagRepository.findTagsByPostId(1L)).willReturn(tags);
@@ -165,7 +165,7 @@ public class PostServiceTest {
 
   @Test
   @DisplayName("게시글 리스트 조회 성공 테스트")
-  void getPostsSuccess() {
+  void successGetPosts() {
     PageRequest pageable = PageRequest.of(0, 10);
     Page<Post> postsPage = new PageImpl<>(List.of(post), pageable, 1);
 
@@ -180,7 +180,7 @@ public class PostServiceTest {
 
   @Test
   @DisplayName("게시글 리스트 조회 실패 테스트 - 게시글 없음")
-  void getPostsFail() {
+  void failGetPosts() {
     PageRequest pageable = PageRequest.of(0, 10);
     Page<Post> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
@@ -194,7 +194,7 @@ public class PostServiceTest {
 
   @Test
   @DisplayName("게시글 수정 성공 테스트")
-  void updatePostSuccess() {
+  void successUpdatePost() {
     // Given
     given(postRepository.findById(1L)).willReturn(Optional.of(post));
     given(drinkRepository.findById(1L)).willReturn(Optional.of(drink));
@@ -226,7 +226,7 @@ public class PostServiceTest {
 
   @Test
   @DisplayName("게시글 수정 실패 테스트 - 게시글 ID 없음")
-  void updatePostFailNoPostId() {
+  void failNoPostIdUpdatePost() {
     // Given
     PostRequest updatedRequest = new PostRequest();
     updatedRequest.setDrinkId(1L);
@@ -242,7 +242,7 @@ public class PostServiceTest {
 
   @Test
   @DisplayName("게시글 삭제 성공 테스트")
-  void deletePostSuccess() {
+  void successDeletePost() {
     // Given
     given(postRepository.findById(1L)).willReturn(Optional.of(post));
     given(memberService.getMember()).willReturn(member);
@@ -261,7 +261,7 @@ public class PostServiceTest {
 
   @Test
   @DisplayName("게시글 삭제 실패 테스트 - 권한 없음")
-  void deletePostFail() {
+  void failDeletePost() {
     // Given
     Member anotherMember = Member.builder().id(2L).name("Jane").role(Role.USER).build();
     post.setMember(anotherMember);

--- a/src/test/java/com/onedrinktoday/backend/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/post/service/PostServiceTest.java
@@ -1,0 +1,289 @@
+package com.onedrinktoday.backend.domain.post.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.onedrinktoday.backend.domain.drink.entity.Drink;
+import com.onedrinktoday.backend.domain.drink.repository.DrinkRepository;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.domain.notification.service.NotificationService;
+import com.onedrinktoday.backend.domain.post.dto.PostRequest;
+import com.onedrinktoday.backend.domain.post.dto.PostResponse;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.post.repository.PostRepository;
+import com.onedrinktoday.backend.domain.postTag.entity.PostTag;
+import com.onedrinktoday.backend.domain.postTag.repository.PostTagRepository;
+import com.onedrinktoday.backend.domain.region.entity.Region;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import com.onedrinktoday.backend.domain.tag.repository.TagRepository;
+import com.onedrinktoday.backend.global.cache.CacheService;
+import com.onedrinktoday.backend.global.exception.CustomException;
+import com.onedrinktoday.backend.global.type.Role;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class PostServiceTest {
+
+  @InjectMocks
+  private PostService postService;
+
+  @Mock
+  private PostRepository postRepository;
+
+  @Mock
+  private MemberService memberService;
+
+  @Mock
+  private DrinkRepository drinkRepository;
+
+  @Mock
+  private TagRepository tagRepository;
+
+  @Mock
+  private PostTagRepository postTagRepository;
+
+  @Mock
+  private NotificationService notificationService;
+
+  @Mock
+  private CacheService cacheService;
+
+  @Mock
+  private CacheManager cacheManager;
+
+  private PostRequest postRequest;
+  private Post post;
+  private Member member;
+  private Region region;
+  private Drink drink;
+  private List<Tag> tags;
+
+  @BeforeEach
+  void setUp() {
+    member = Member.builder().id(1L).name("John").role(Role.USER).build();
+    region = Region.builder().id(1L).placeName("서울특별시").build();
+    drink = Drink.builder().id(1L).name("막걸리").region(region).build();
+    post = Post.builder().id(1L).member(member).drink(drink).content("맛있는 막걸리입니다!").viewCount(0).build();
+    tags = Arrays.asList(new Tag(1L, "달콤"), new Tag(2L, "시원"));
+
+    postRequest = new PostRequest();
+    postRequest.setDrinkId(1L);
+    postRequest.setContent("맛있는 막걸리입니다!");
+    postRequest.setRating(4.5F);
+    postRequest.setTag(Arrays.asList("달콤", "시원"));
+  }
+
+  @Test
+  @DisplayName("게시글 생성 성공 테스트")
+  void createPostSuccess() {
+    // Given
+    given(memberService.getMember()).willReturn(member);
+    given(drinkRepository.findById(1L)).willReturn(Optional.of(drink));
+
+    Tag newTag1 = Tag.builder().tagId(1L).tagName("달콤").build();
+    Tag newTag2 = Tag.builder().tagId(2L).tagName("시원").build();
+
+    given(tagRepository.findByTagName("달콤")).willReturn(Optional.of(newTag1));
+    given(tagRepository.findByTagName("시원")).willReturn(Optional.of(newTag2));
+
+    given(postRepository.save(any(Post.class))).willReturn(post);
+
+    PostTag postTag1 = new PostTag(post, newTag1);
+    PostTag postTag2 = new PostTag(post, newTag2);
+    given(postTagRepository.save(any(PostTag.class))).willReturn(postTag1).willReturn(postTag2);
+
+    ArgumentCaptor<List<Tag>> tagListCaptor = ArgumentCaptor.forClass(List.class);
+
+    // When
+    PostResponse postResponse = postService.createPost(postRequest);
+
+    // Then
+    assertNotNull(postResponse);
+    assertEquals(postResponse.getContent(), "맛있는 막걸리입니다!");
+    verify(notificationService).tagFollowPostNotification(eq(post.getId()), tagListCaptor.capture());
+  }
+
+  @Test
+  @DisplayName("게시글 생성 실패 테스트 - Drink ID 없음")
+  void createPostFailNoDrinkId() {
+    // Given
+    postRequest.setDrinkId(999L); // 존재하지 않는 Drink ID
+    given(drinkRepository.findById(999L)).willReturn(Optional.empty());
+
+    // When & Then
+    assertThrows(IllegalArgumentException.class, () -> postService.createPost(postRequest));
+  }
+
+  @Test
+  @DisplayName("게시글 조회 성공 테스트")
+  void getPostByIdSuccess() {
+    // Given
+    given(postRepository.findById(1L)).willReturn(Optional.of(post));
+    given(postTagRepository.findTagsByPostId(1L)).willReturn(tags);
+    given(cacheService.getAverageRating(1L)).willReturn(4.0);
+
+    // When
+    PostResponse postResponse = postService.getPostById(1L);
+
+    // Then
+    assertNotNull(postResponse);
+    assertEquals(postResponse.getContent(), "맛있는 막걸리입니다!");
+  }
+
+  @Test
+  @DisplayName("게시글 조회 실패 테스트 - 잘못된 게시글 ID")
+  void getPostByIdFail() {
+    // Given
+    given(postRepository.findById(999L)).willReturn(Optional.empty());
+
+    // When & Then
+    assertThrows(IllegalArgumentException.class, () -> postService.getPostById(999L));
+  }
+
+  @Test
+  @DisplayName("게시글 리스트 조회 성공 테스트")
+  void getPostsSuccess() {
+    PageRequest pageable = PageRequest.of(0, 10);
+    Page<Post> postsPage = new PageImpl<>(List.of(post), pageable, 1);
+
+    given(postRepository.findAllByOrderByViewCountDesc(pageable)).willReturn(postsPage);
+
+    Page<PostResponse> postResponses = postService.getAllPosts(pageable, "viewCount");
+
+    assertNotNull(postResponses);
+    assertEquals(1, postResponses.getTotalElements());
+    assertEquals("맛있는 막걸리입니다!", postResponses.getContent().get(0).getContent());
+  }
+
+  @Test
+  @DisplayName("게시글 리스트 조회 실패 테스트 - 게시글 없음")
+  void getPostsFail() {
+    PageRequest pageable = PageRequest.of(0, 10);
+    Page<Post> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+    given(postRepository.findAllByOrderByViewCountDesc(pageable)).willReturn(emptyPage);
+
+    Page<PostResponse> postResponses = postService.getAllPosts(pageable, "viewCount");
+
+    assertNotNull(postResponses);
+    assertEquals(0, postResponses.getTotalElements());
+  }
+
+  @Test
+  @DisplayName("게시글 수정 성공 테스트")
+  void updatePostSuccess() {
+    // Given
+    given(postRepository.findById(1L)).willReturn(Optional.of(post));
+    given(drinkRepository.findById(1L)).willReturn(Optional.of(drink));
+
+    Tag newTag1 = Tag.builder().tagId(1L).tagName("씁쓸").build();
+    Tag newTag2 = Tag.builder().tagId(2L).tagName("새콤").build();
+
+    // 태그 저장 로직 수정
+    given(tagRepository.findByTagName("씁쓸")).willReturn(Optional.of(newTag1));
+    given(tagRepository.findByTagName("새콤")).willReturn(Optional.of(newTag2));
+
+    PostRequest updatedRequest = new PostRequest();
+    updatedRequest.setDrinkId(1L);
+    updatedRequest.setContent("업데이트된 내용입니다!");
+    updatedRequest.setRating(5.0F);
+    updatedRequest.setTag(Arrays.asList("씁쓸", "새콤"));
+
+    // When
+    PostResponse postResponse = postService.updatePost(1L, updatedRequest);
+
+    // Then
+    assertNotNull(postResponse);
+    assertEquals("업데이트된 내용입니다!", postResponse.getContent());
+    assertEquals(5.0F, postResponse.getRating());
+    assertEquals(2, postResponse.getTags().size());
+    assertEquals("씁쓸", postResponse.getTags().get(0).getTagName());
+    assertEquals("새콤", postResponse.getTags().get(1).getTagName());
+  }
+
+  @Test
+  @DisplayName("게시글 수정 실패 테스트 - 게시글 ID 없음")
+  void updatePostFailNoPostId() {
+    // Given
+    PostRequest updatedRequest = new PostRequest();
+    updatedRequest.setDrinkId(1L);
+    updatedRequest.setContent("업데이트된 내용입니다!");
+    updatedRequest.setRating(5.0F);
+    updatedRequest.setTag(Arrays.asList("씁쓸", "새콤"));
+
+    given(postRepository.findById(999L)).willReturn(Optional.empty());
+
+    // When & Then
+    assertThrows(IllegalArgumentException.class, () -> postService.updatePost(999L, updatedRequest));
+  }
+
+  @Test
+  @DisplayName("게시글 삭제 성공 테스트")
+  void deletePostSuccess() {
+    // Given
+    given(postRepository.findById(1L)).willReturn(Optional.of(post));
+    given(memberService.getMember()).willReturn(member);
+
+    Cache cache = mock(Cache.class);
+    given(cacheManager.getCache("avg-rating")).willReturn(cache);
+    doNothing().when(cache).evict(1L);
+
+    // When
+    postService.deletePostById(1L);
+
+    // Then
+    verify(postRepository).deleteById(1L);
+    verify(cacheManager.getCache("avg-rating")).evict(1L);
+  }
+
+  @Test
+  @DisplayName("게시글 삭제 실패 테스트 - 권한 없음")
+  void deletePostFail() {
+    // Given
+    Member anotherMember = Member.builder().id(2L).name("Jane").role(Role.USER).build();
+    post.setMember(anotherMember);
+    given(postRepository.findById(1L)).willReturn(Optional.of(post));
+    given(memberService.getMember()).willReturn(member); // 현재 로그인된 사용자는 작성자가 아님
+
+    // When & Then
+    CustomException exception = assertThrows(CustomException.class, () -> postService.deletePostById(1L));
+    assertEquals("접근이 거부되었습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("캐시에서 평균 평점 가져오기 테스트")
+  void getAverageRatingFromCache() {
+    // Given
+    given(cacheService.getAverageRating(1L)).willReturn(4.5);
+
+    // When
+    Double rating = cacheService.getAverageRating(1L);
+
+    // Then
+    assertNotNull(rating);
+    assertEquals(4.5, rating);
+  }
+}


### PR DESCRIPTION
### 변경사항
- master 브랜치 충돌 rebase 병합 
- Post(게시글) 평점 기존 Float 타입에서 AVG() 함수 사용으로 형 변환 프로세스를 없애기 위해 Double 타입으로 변경 
- Post(게시글) 전체 게시글 최신순 / 조회수 정렬 조회 기능 구현
- Post(게시글) 이미지 업로드 시 우선순위(1순위 : 게시글 업로드 이미지, 2순위 : 특산주 기본 이미지) 기능 구현 
- PostService 테스트 코드 작성 
  - `successCreatePost` - 게시글 생성 성공 테스트
    - `memberService.getMember()`를 통해서 사용자 정보를 가져오고, 각 태그와 생성된 게시글 내용 확인, 태그 관련 알림 서비스가 잘 호출되는지 검증
  - `failNoDrinkIdCreatePost` - 게시글 생성 실패 테스트
    - 잘못된 음료 ID 999L을 설정하고, `drinkRepository.findById(999L)`이 빈 값을 반환하도록 설정, IllegalArgumentException 예외가 발생하는지 확인하여 음료가 없을 경우 적절히 예외 처리가 되는지 검증
  - `successGetPostById` - 게시글 조회 성공 테스트
    - `postRepository.findById(1L)`와 게시글에 연결된 태그 정보를 설정하고, 음료에 대한 평균 평점을 캐시에서 가져옴. `postService.getPostById(1L)` 메서드를 호출하여 게시글 조회
  - `getPostByIdFail` - 게시글 조회 실패 테스트
    - 잘못된 게시글 ID 999L에 대해 `postRepository.findById(999L)`가 빈 값을 반환하도록 설정. IllegalArgumentException 예외가 발생하는지 확인
  - `successGetPosts` - 게시글 리스트 조회 성공 테스트
    - 페이지 정보(PageRequest)와 게시글 리스트(`postRepository.findAllByOrderByViewCountDesc(pageable)`)를 설정. `postService.getAllPosts(pageable, "viewCount")`를 호출하여 게시글 리스트를 조회
  - `failGetPosts` - 게시글 리스트 조회 실패 테스트 (게시글 없음) 
    - 빈 페이지(PageImpl)를 반환하도록 설정. `postService.getAllPosts(pageable, "viewCount")`를 호출하여 게시글 리스트를 조회. 반환된 게시글 리스트가 비어 있는지 검증
  - `successUpdatePost` - 게시글 수정 성공 테스트 
    - 기존 게시글 정보(`postRepository.findById(1L)`)와 음료 정보와 수정할 태그 정보(`tagRepository.findByTagName()`)를 설정. `postService.updatePost(1L, updatedRequest)` 메서드를 호출하여 게시글을 수정
  - `failNoPostIdUpdatePost` - 게시글 수정 실패 테스트 (잘못된 게시글 ID)
    - 잘못된 게시글 ID 999L에 대해 `postRepository.findById(999L)`가 빈 값을 반환하도록 설정. IllegalArgumentException 예외가 발생하는지 확인
  - `successDeletePost` - 게시글 삭제 성공 테스트 
    - 게시글 정보(`postRepository.findById(1L)`)와 현재 로그인한 사용자 정보(`memberService.getMember()`)를 설정. 캐시에서 해당 음료의 평균 평점을 제거하는 로직을 추가. `postService.deletePostById(1L)` 메서드를 호출하여 게시글을 삭제
  - `failDeletePost` - 게시글 삭제 실패 테스트 (권한 없음)
    - 다른 작성자가 게시글을 작성하도록 설정하고, 현재 사용자가 해당 게시글을 삭제하려고 시도. `postService.deletePostById(1L)`를 호출. CustomException 예외가 발생하는지 확인
  - `getAverageRatingFromCache` - 캐시에서 평균 평점 가져오기 테스트
    - `cacheService.getAverageRating(1L)`이 4.5를 반환하도록 설정. `cacheService.getAverageRating(1L)` 메서드를 호출 후 확인

<br>

- PostController 테스트 코드 작성 
  - `successCreatePost` - 게시글 생성 성공 테스트 
    - `postService.createPost()`가 호출되었을 때, postResponse 객체를 반환하도록 모의 객체를 설정. `POST /api/posts` API 엔드포인트를 호출하여 게시글을 생성
  - successGetPostById - 게시글 조회 성공 테스트
    - `postService.getPostById(1L)`이 호출되면, postResponse 객체를 반환. `GET /api/posts/1` API 엔드포인트를 호출하여 ID가 1인 게시글을 조회
  - `failNotFoundGetPostById` - 게시글 조회 실패 테스트 (존재하지 않는 게시글)
    - `postService.getPostById(999L)`가 호출되었을 때, IllegalArgumentException을 발생시키도록 설정. `GET /api/posts/999` API 엔드포인트를 호출하여 존재하지 않는 게시글을 조회
  - `successGetAllPosts` - 게시글 리스트 조회 성공 테스트 
    - `postService.getAllPosts()`가 페이지 처리된 게시글 목록을 반환하도록 설정. `GET /api/posts` API 엔드포인트를 호출하여 게시글 목록을 조회
  - `successUpdatePostById` - 게시글 수정 성공 테스트
    - `postService.updatePost(1L, postRequest)`가 호출되면 수정된 게시글 정보를 반환하도록 설정. `PUT /api/posts/1` API 엔드포인트를 호출하여 게시글을 수정 
  - `failNotFoundUpdatePostById` - 게시글 수정 실패 테스트 (존재하지 않는 게시글)
    - `postService.updatePost(999L, postRequest)`가 호출되었을 때, IllegalArgumentException을 발생시키도록 설정. `PUT /api/posts/999` API 엔드포인트를 호출하여 존재하지 않는 게시글을 수정 시도
  - `successDeletePostById` - 게시글 삭제 성공 테스트 
    - `postService.deletePostById(1L)`가 정상적으로 호출될 때 아무 동작도 하지 않도록 설정. `DELETE /api/posts/1` API 엔드포인트를 호출하여 게시글을 삭제
  - `failNotFoundDeletePostById` - 게시글 삭제 실패 테스트 (존재하지 않는 게시글)
    - `postService.deletePostById(999L)`가 호출되었을 때, IllegalArgumentException을 발생시키도록 설정. `DELETE /api/posts/999` API 엔드포인트를 호출하여 존재하지 않는 게시글을 삭제 시도


### 테스트
- [x] 테스트 코드
- [x] API 테스트 