### PR TITLE
feat: 회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/comment/dto/CommentResponse.java
@@ -23,10 +23,16 @@ public class CommentResponse {
   private LocalDateTime updatedAt;
 
   public static CommentResponse from(Comment comment) {
+
+    String memberName = "탈퇴한 사용자";
+    if (comment.getMember() != null) {
+      memberName = comment.isAnonymous() ? "익명" : comment.getMember().getName();
+    }
+
     return CommentResponse.builder()
         .id(comment.getId())
-        .memberId(comment.getMember().getId())
-        .memberName(comment.getMember().getName())
+        .memberId(comment.getMember() != null ? comment.getMember().getId() : null)
+        .memberName(memberName)
         .postId(comment.getPost().getId())
         .content(comment.getContent())
         .anonymous(comment.isAnonymous())

--- a/src/main/java/com/onedrinktoday/backend/domain/comment/entity/Comment.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/comment/entity/Comment.java
@@ -35,6 +35,7 @@ public class Comment {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Setter
   @ManyToOne
   @JoinColumn(name = "member_id")
   private Member member;

--- a/src/main/java/com/onedrinktoday/backend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,9 @@
 package com.onedrinktoday.backend.domain.comment.repository;
 
 import com.onedrinktoday.backend.domain.comment.entity.Comment;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +13,8 @@ import org.springframework.stereotype.Repository;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
   Page<Comment> findByPostId(Long postId, Pageable pageable);
+
+  void deleteAllByPost(Post post);
+
+  List<Comment> findAllByMember(Member member);
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import com.onedrinktoday.backend.global.security.TokenDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -96,5 +97,11 @@ public class MemberController {
       @Valid @RequestBody MemberRequest.UpdateInfo request) {
 
     return ResponseEntity.ok(memberService.updateMemberInfo(request));
+  }
+
+  @DeleteMapping("/members")
+  public ResponseEntity<String> withdrawMember() {
+    memberService.withdrawMember();
+    return ResponseEntity.ok("회원 탈퇴 완료");
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
@@ -10,9 +10,9 @@ import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
 import com.onedrinktoday.backend.domain.post.entity.Post;
 import com.onedrinktoday.backend.domain.post.repository.PostRepository;
-import com.onedrinktoday.backend.domain.postTag.repository.PostTagRepository;
 import com.onedrinktoday.backend.domain.registration.entity.Registration;
 import com.onedrinktoday.backend.domain.registration.repository.RegistrationRepository;
+import com.onedrinktoday.backend.domain.tagFollow.repository.TagFollowRepository;
 import com.onedrinktoday.backend.global.exception.CustomException;
 import com.onedrinktoday.backend.global.exception.ErrorCode;
 import com.onedrinktoday.backend.global.security.JwtProvider;
@@ -36,7 +36,7 @@ public class MemberService {
   private final MemberRepository memberRepository;
   private final CommentRepository commentRepository;
   private final PostRepository postRepository;
-  private final PostTagRepository postTagRepository;
+  private final TagFollowRepository tagFollowRepository;
   private final RegistrationRepository registrationRepository;
   private final BCryptPasswordEncoder bCryptPasswordEncoder;
   private final JwtProvider jwtProvider;
@@ -186,13 +186,12 @@ public class MemberService {
   public void withdrawMember() {
     Member member = getMember();
 
+    tagFollowRepository.deleteByMember(member);
+
     List<Post> posts = postRepository.findAllByMember(member);
     if (!posts.isEmpty()) {
-      for (Post post : posts) {
-        commentRepository.deleteAllByPost(post);
-        postTagRepository.deleteByPostId(post.getId());
-      }
-      postRepository.deleteAll(posts);
+      posts.forEach(post -> post.setMember(null));
+      postRepository.saveAll(posts);
     }
 
     List<Comment> comments = commentRepository.findAllByMember(member);

--- a/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
@@ -168,4 +168,8 @@ public class MemberService {
     member.setPassword(bCryptPasswordEncoder.encode(newPassword));
     memberRepository.save(member);
   }
+
+  public void withdrawMember() {
+    memberRepository.delete(getMember());
+  }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
@@ -188,6 +188,12 @@ public class MemberService {
 
     tagFollowRepository.deleteByMember(member);
 
+    handleEntitiesForWithdrawMember(member);
+
+    memberRepository.delete(member);
+  }
+
+  private void handleEntitiesForWithdrawMember(Member member) {
     List<Post> posts = postRepository.findAllByMember(member);
     if (!posts.isEmpty()) {
       posts.forEach(post -> post.setMember(null));
@@ -205,7 +211,5 @@ public class MemberService {
       registrations.forEach(registration -> registration.setMember(null));
       registrationRepository.saveAll(registrations);
     }
-
-    memberRepository.delete(member);
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
@@ -1,11 +1,18 @@
 package com.onedrinktoday.backend.domain.member.service;
 
+import com.onedrinktoday.backend.domain.comment.entity.Comment;
+import com.onedrinktoday.backend.domain.comment.repository.CommentRepository;
 import com.onedrinktoday.backend.domain.member.dto.MemberRequest.SignIn;
 import com.onedrinktoday.backend.domain.member.dto.MemberRequest.SignUp;
 import com.onedrinktoday.backend.domain.member.dto.MemberRequest.UpdateInfo;
 import com.onedrinktoday.backend.domain.member.dto.MemberResponse;
 import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.post.repository.PostRepository;
+import com.onedrinktoday.backend.domain.postTag.repository.PostTagRepository;
+import com.onedrinktoday.backend.domain.registration.entity.Registration;
+import com.onedrinktoday.backend.domain.registration.repository.RegistrationRepository;
 import com.onedrinktoday.backend.global.exception.CustomException;
 import com.onedrinktoday.backend.global.exception.ErrorCode;
 import com.onedrinktoday.backend.global.security.JwtProvider;
@@ -15,16 +22,22 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
   private final MemberRepository memberRepository;
+  private final CommentRepository commentRepository;
+  private final PostRepository postRepository;
+  private final PostTagRepository postTagRepository;
+  private final RegistrationRepository registrationRepository;
   private final BCryptPasswordEncoder bCryptPasswordEncoder;
   private final JwtProvider jwtProvider;
   private final EmailService emailService;
@@ -169,7 +182,31 @@ public class MemberService {
     memberRepository.save(member);
   }
 
+  @Transactional
   public void withdrawMember() {
-    memberRepository.delete(getMember());
+    Member member = getMember();
+
+    List<Post> posts = postRepository.findAllByMember(member);
+    if (!posts.isEmpty()) {
+      for (Post post : posts) {
+        commentRepository.deleteAllByPost(post);
+        postTagRepository.deleteByPostId(post.getId());
+      }
+      postRepository.deleteAll(posts);
+    }
+
+    List<Comment> comments = commentRepository.findAllByMember(member);
+    if (!comments.isEmpty()) {
+      comments.forEach(comment -> comment.setMember(null));
+      commentRepository.saveAll(comments);
+    }
+
+    List<Registration> registrations = registrationRepository.findAllByMember(member);
+    if (!registrations.isEmpty()) {
+      registrations.forEach(registration -> registration.setMember(null));
+      registrationRepository.saveAll(registrations);
+    }
+
+    memberRepository.delete(member);
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/dto/PostResponse.java
@@ -37,12 +37,14 @@ public class PostResponse {
   private LocalDateTime updatedAt;
 
   public static PostResponse of(Post post, List<Tag> tags) {
-
+    String memberName = post.getMember() != null ? post.getMember().getName() : "탈퇴한 사용자";
+    Long memberId = post.getMember() != null ? post.getMember().getId() : null;
     String imageUrl = post.getImageUrl() != null ? post.getImageUrl() : post.getDrink().getImageUrl();
+
     return PostResponse.builder()
         .id(post.getId())
-        .memberId(post.getMember().getId())
-        .memberName(post.getMember().getName())
+        .memberId(memberId)
+        .memberName(memberName)
         .drink(DrinkResponse.from(post.getDrink()))
         .type(post.getType())
         .content(post.getContent())

--- a/src/main/java/com/onedrinktoday/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/repository/PostRepository.java
@@ -1,6 +1,8 @@
 package com.onedrinktoday.backend.domain.post.repository;
 
+import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.post.entity.Post;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +12,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
   @Query(value = "select AVG(rating) from post where drink_id = :drinkId", nativeQuery = true)
   Double getAverageRating(Long drinkId);
+
+  List<Post> findAllByMember(Member member);
 
   // 최신순으로 정렬
   Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);

--- a/src/main/java/com/onedrinktoday/backend/domain/registration/dto/RegistrationResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/registration/dto/RegistrationResponse.java
@@ -29,10 +29,13 @@ public class RegistrationResponse {
   private LocalDateTime createdAt;
 
   public static RegistrationResponse from(Registration registration) {
+    Long memberId = registration.getMember() != null ? registration.getMember().getId() : null;
+    String memberName = memberId != null ? registration.getMember().getName() : "탈퇴한 사용자";
+
     return RegistrationResponse.builder()
         .id(registration.getId())
-        .memberId(registration.getMember().getId())
-        .memberName(registration.getMember().getName())
+        .memberId(memberId)
+        .memberName(memberName)
         .placeName(registration.getRegion().getPlaceName())
         .drinkName(registration.getDrinkName())
         .type(registration.getType())

--- a/src/main/java/com/onedrinktoday/backend/domain/registration/repository/RegistrationRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/registration/repository/RegistrationRepository.java
@@ -1,10 +1,13 @@
 package com.onedrinktoday.backend.domain.registration.repository;
 
+import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.registration.entity.Registration;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RegistrationRepository extends JpaRepository<Registration, Long> {
 
+  List<Registration> findAllByMember(Member member);
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/tagFollow/repository/TagFollowRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/tagFollow/repository/TagFollowRepository.java
@@ -15,4 +15,6 @@ public interface TagFollowRepository extends JpaRepository<TagFollow, Long> {
   boolean existsByMemberAndTag(Member member, Tag tag);
 
   List<TagFollow> findByTag(Tag tag);
+
+  void deleteByMember(Member member);
 }

--- a/src/test/java/com/onedrinktoday/backend/domain/member/controller/MemberRegistrationControllerTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/member/controller/MemberRegistrationControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -431,6 +432,22 @@ public class MemberRegistrationControllerTest {
             .content(new ObjectMapper().writeValueAsString(updateInfo)))
         .andExpect(status().isNotFound())
         .andExpect(content().string(MEMBER_NOT_FOUND.getMessage()))
+        .andDo(print());
+  }
+
+  @Test
+  @DisplayName("회원탈퇴 성공")
+  public void successWithdrawMember() throws Exception {
+    //given
+    String successMessage = "회원 탈퇴 완료";
+
+    //when
+    //then
+    mockMvc.perform(delete("/api/members")
+            .with(csrf())
+            .header("Access-Token", TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(content().string(successMessage))
         .andDo(print());
   }
 }

--- a/src/test/java/com/onedrinktoday/backend/domain/member/service/MemberRigistrationServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/member/service/MemberRigistrationServiceTest.java
@@ -12,19 +12,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.onedrinktoday.backend.domain.comment.entity.Comment;
+import com.onedrinktoday.backend.domain.comment.repository.CommentRepository;
 import com.onedrinktoday.backend.domain.member.dto.MemberRequest.SignIn;
 import com.onedrinktoday.backend.domain.member.dto.MemberRequest.SignUp;
 import com.onedrinktoday.backend.domain.member.dto.MemberRequest.UpdateInfo;
 import com.onedrinktoday.backend.domain.member.dto.MemberResponse;
 import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.post.repository.PostRepository;
+import com.onedrinktoday.backend.domain.postTag.repository.PostTagRepository;
 import com.onedrinktoday.backend.domain.region.entity.Region;
 import com.onedrinktoday.backend.domain.region.repository.RegionRepository;
+import com.onedrinktoday.backend.domain.registration.entity.Registration;
+import com.onedrinktoday.backend.domain.registration.repository.RegistrationRepository;
 import com.onedrinktoday.backend.global.exception.CustomException;
 import com.onedrinktoday.backend.global.exception.ErrorCode;
 import com.onedrinktoday.backend.global.security.JwtProvider;
@@ -46,8 +53,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 public class MemberRigistrationServiceTest {
@@ -63,6 +72,18 @@ public class MemberRigistrationServiceTest {
 
   @Mock
   private RegionRepository regionRepository;
+
+  @Mock
+  private PostRepository postRepository;
+
+  @Mock
+  private RegistrationRepository registrationRepository;
+
+  @Mock
+  private CommentRepository commentRepository;
+
+  @Mock
+  private PostTagRepository postTagRepository;
 
   @Mock
   private JwtProvider jwtProvider;
@@ -160,8 +181,9 @@ public class MemberRigistrationServiceTest {
 
     when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
     when(bCryptPasswordEncoder.matches(password, encodedPassword)).thenReturn(true);
-    when(jwtProvider.createAccessToken(member.getId(),email, Role.USER)).thenReturn("accessToken");
-    when(jwtProvider.createRefreshToken(member.getId(),email, Role.USER)).thenReturn("refreshToken");
+    when(jwtProvider.createAccessToken(member.getId(), email, Role.USER)).thenReturn("accessToken");
+    when(jwtProvider.createRefreshToken(member.getId(), email, Role.USER)).thenReturn(
+        "refreshToken");
 
     //when
     TokenDto tokenDto = memberService.signIn(signInRequest);
@@ -212,7 +234,8 @@ public class MemberRigistrationServiceTest {
         .refreshToken(refreshToken).build();
 
     when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
-    when(jwtProvider.createAccessToken(member.getId(),email, Role.USER)).thenReturn(newAccessToken);
+    when(jwtProvider.createAccessToken(member.getId(), email, Role.USER)).thenReturn(
+        newAccessToken);
 
     //when
     TokenDto tokenDto = memberService.refreshAccessToken(refreshToken);
@@ -398,7 +421,7 @@ public class MemberRigistrationServiceTest {
     existMember.setRole(Role.USER);
 
     when(memberRepository.findByEmail(existMember.getEmail())).thenReturn(Optional.of(existMember));
-    when(jwtProvider.createResetToken(member.getId(),email, Role.USER)).thenReturn(token);
+    when(jwtProvider.createResetToken(member.getId(), email, Role.USER)).thenReturn(token);
 
     ArgumentCaptor<String> emailArgumentCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> resetLinkArgumentCaptor = ArgumentCaptor.forClass(String.class);
@@ -522,23 +545,54 @@ public class MemberRigistrationServiceTest {
   }
 
   @Test
-  @DisplayName("회원 탈퇴 성공")
+  @Transactional
   void successWithdrawMember() {
     //given
-    String email = member.getEmail();
-    when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
-    doNothing().when(memberRepository).delete(member);
+    Member existMember = Member.builder()
+        .id(1L)
+        .region(region)
+        .name(member.getName())
+        .email(member.getEmail())
+        .birthDate(member.getBirthDate())
+        .favorDrinkType(member.getFavorDrinkType())
+        .role(member.getRole())
+        .alarmEnabled(true)
+        .imageUrl(member.getImageUrl())
+        .build();
 
-    //MemberDetail 사용하여 인증 정보 확인
-    MemberDetail memberDetail = new MemberDetail(MemberResponse.from(member));
+    Post post = Post.builder()
+        .id(1L)
+        .build();
+    Comment comment = Comment.builder()
+        .id(1L)
+        .build();
+    Registration registration = Registration.builder()
+        .id(1L)
+        .build();
+
+    when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(existMember));
+    when(postRepository.findAllByMember(existMember)).thenReturn(List.of(post));
+    when(commentRepository.findAllByMember(existMember)).thenReturn(List.of(comment));
+    when(registrationRepository.findAllByMember(existMember)).thenReturn(List.of(registration));
+
+    MemberResponse memberResponse = MemberResponse.from(existMember);
+    MemberDetail memberDetail = new MemberDetail(memberResponse);
     Authentication authentication = new UsernamePasswordAuthenticationToken(memberDetail, null);
-    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    SecurityContext securityContext = mock(SecurityContext.class);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
 
     //when
     memberService.withdrawMember();
 
     //then
-    verify(memberRepository, times(1)).delete(member);
+    verify(commentRepository, times(1)).deleteAllByPost(post);
+    verify(postTagRepository, times(1)).deleteByPostId(post.getId());
+    verify(postRepository, times(1)).deleteAll(List.of(post));
+    verify(commentRepository, times(1)).saveAll(List.of(comment));
+    verify(registrationRepository, times(1)).saveAll(List.of(registration));
+    verify(memberRepository, times(1)).delete(existMember); // Ensure delete was called
   }
 
   @Test

--- a/src/test/java/com/onedrinktoday/backend/domain/member/service/MemberRigistrationServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/member/service/MemberRigistrationServiceTest.java
@@ -27,11 +27,11 @@ import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
 import com.onedrinktoday.backend.domain.post.entity.Post;
 import com.onedrinktoday.backend.domain.post.repository.PostRepository;
-import com.onedrinktoday.backend.domain.postTag.repository.PostTagRepository;
 import com.onedrinktoday.backend.domain.region.entity.Region;
 import com.onedrinktoday.backend.domain.region.repository.RegionRepository;
 import com.onedrinktoday.backend.domain.registration.entity.Registration;
 import com.onedrinktoday.backend.domain.registration.repository.RegistrationRepository;
+import com.onedrinktoday.backend.domain.tagFollow.repository.TagFollowRepository;
 import com.onedrinktoday.backend.global.exception.CustomException;
 import com.onedrinktoday.backend.global.exception.ErrorCode;
 import com.onedrinktoday.backend.global.security.JwtProvider;
@@ -83,7 +83,7 @@ public class MemberRigistrationServiceTest {
   private CommentRepository commentRepository;
 
   @Mock
-  private PostTagRepository postTagRepository;
+  private TagFollowRepository tagFollowRepository;
 
   @Mock
   private JwtProvider jwtProvider;
@@ -562,12 +562,15 @@ public class MemberRigistrationServiceTest {
 
     Post post = Post.builder()
         .id(1L)
+        .member(existMember)
         .build();
     Comment comment = Comment.builder()
         .id(1L)
+        .member(existMember)
         .build();
     Registration registration = Registration.builder()
         .id(1L)
+        .member(existMember)
         .build();
 
     when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(existMember));
@@ -587,12 +590,14 @@ public class MemberRigistrationServiceTest {
     memberService.withdrawMember();
 
     //then
-    verify(commentRepository, times(1)).deleteAllByPost(post);
-    verify(postTagRepository, times(1)).deleteByPostId(post.getId());
-    verify(postRepository, times(1)).deleteAll(List.of(post));
+    verify(tagFollowRepository, times(1)).deleteByMember(existMember);
+    verify(postRepository, times(1)).findAllByMember(existMember);
+    verify(commentRepository, times(1)).findAllByMember(existMember);
+    verify(registrationRepository, times(1)).findAllByMember(existMember);
+    verify(postRepository, times(1)).saveAll(List.of(post));
     verify(commentRepository, times(1)).saveAll(List.of(comment));
     verify(registrationRepository, times(1)).saveAll(List.of(registration));
-    verify(memberRepository, times(1)).delete(existMember); // Ensure delete was called
+    verify(memberRepository, times(1)).delete(existMember);
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
- 사용자 회원탈퇴 기능 구현
- MemberController
   - 회원탈퇴 기능을 처리하는 API를 추가하였습니다.
   - 사용자가 회원탈퇴 요청 시, 인증된 사용자를 찾아서 탈퇴를 처리합니다.
 - MemberService
   - 현재 로그인한 사용자를 인증 정보로 가져와 해당 사용자의 이메일을 사용해 데이터베이스에서 회원 정보를 조회합니다.
   - 회원 정보를 조회한 후, 해당 회원이 작성한 게시글, 댓글, 등록 정보를 가져와서 연관된 사용자 정보를 null로 설정하고 저장합니다.
   - 회원 정보는 deletedAt 필드가 설정되어 탈퇴 상태로 표시되며, 실제 데이터베이스에서는 삭제되지 않고 비활성화됩니다.
   - 회원이 작성한 게시글의 작성자는 "탈퇴한 사용자"로 표시됩니다.
   - 탈퇴한 사용자의 게시글에 있는 댓글은 삭제되지 않고, 탈퇴한 댓글의 작성자 정보는 "탈퇴한 사용자"로 변경되며, memberId는 null로 설정됩니다.
   - tagFollowRepository를 사용하여 태그 팔로우 정보도 삭제합니다.
   - **PostResponse**: 작성자가 탈퇴한 경우 "탈퇴한 사용자"으로 표시 되고 memberId는 null됩니다. 탈퇴한 사용자의 게시글에 있는 댓글은 삭제되지 않습니다. 
   - **CommentResponse**: 작성자가 탈퇴한 경우 "탈퇴한 사용자"으로 표시됩니다. 익명여부와 상관없이 탈퇴를 한다면 "탈퇴한 사용자"로 변경되고 memberId는 null이 됩니다.
   - **RegistrationResponse**: 작성자가 탈퇴한 경우 사용자 이름은 "탈퇴한 사용자" 그리고 memberId는 null이 됩니다.
 - MemberRegistrationControllerTest
   - 회원 탈퇴 요청이 정상적으로 처리되는지 테스트하였습니다.
   - DELETE 요청을 /api/members 경로로 전송하고, 응답을 검증합니다.
 - MemberRigistrationServiceTest
   - 회원탈퇴 성공
     - 사용자가 존재할 때, `memberService.withdrawMember()` 호출 후 모든 관련 엔티티(게시물, 댓글, 특산주 등록)가 올바르게 업데이트되는지 검증합니다.
     - `SecurityContext`와 `Authentication`을 설정하여 `memberService.withdrawMember(`) 메소드가 현재 로그인된 사용자를 올바르게 인식하도록 합니다.
     - verify 호출을 통해 각 Repository 메소드가 예상대로 호출되었는지 확인합니다.
   - 회원탈퇴 실패
     - 사용자가 존재하지 않을 때, `memberRepository.findByEmail()`이 빈 값을 반환하도록 설정하고, `CustomException`이 발생하는지 검증합니다.
     - `SecurityContext`와 `Authentication`을 설정하여 `memberService.withdrawMember()` 메소드가 현재 로그인된 사용자를 올바르게 인식하도록 합니다.
     - 예외가 발생했을 때 메시지가 예상된 오류 코드 메시지와 일치하는지 확인합니다.
   
**AS-IS**
- 사용자 인증 중복되는 코드는 리팩토링 때 중복을 줄이도록 수정하겠습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 