### PR TITLE
feat: 게시글 검색, 자동완성 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ repositories {
 
 dependencies {
 
+    //es
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/onedrinktoday/backend/domain/autoComplete/AutoCompleteController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/autoComplete/AutoCompleteController.java
@@ -1,0 +1,28 @@
+package com.onedrinktoday.backend.domain.autoComplete;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AutoCompleteController {
+
+  private final AutoCompleteService autoCompleteService;
+
+  @GetMapping("/auto-complete/tag")
+  public ResponseEntity<List<String>> getAutoCompleteTag(@RequestParam String tagName) {
+    return ResponseEntity.ok(autoCompleteService.getAutoCompleteTag(tagName));
+  }
+
+  @GetMapping("/auto-complete/drink")
+  public ResponseEntity<List<String>> getAutoCompleteDrink(@RequestParam String drinkName) {
+    return ResponseEntity.ok(autoCompleteService.getAutoCompleteDrink(drinkName));
+  }
+
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/autoComplete/AutoCompleteController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/autoComplete/AutoCompleteController.java
@@ -16,13 +16,13 @@ public class AutoCompleteController {
   private final AutoCompleteService autoCompleteService;
 
   @GetMapping("/auto-complete/tag")
-  public ResponseEntity<List<String>> getAutoCompleteTag(@RequestParam String tagName) {
-    return ResponseEntity.ok(autoCompleteService.getAutoCompleteTag(tagName));
+  public ResponseEntity<List<String>> getAutoCompleteTag(@RequestParam String name) {
+    return ResponseEntity.ok(autoCompleteService.getAutoCompleteTag(name));
   }
 
   @GetMapping("/auto-complete/drink")
-  public ResponseEntity<List<String>> getAutoCompleteDrink(@RequestParam String drinkName) {
-    return ResponseEntity.ok(autoCompleteService.getAutoCompleteDrink(drinkName));
+  public ResponseEntity<List<String>> getAutoCompleteDrink(@RequestParam String name) {
+    return ResponseEntity.ok(autoCompleteService.getAutoCompleteDrink(name));
   }
 
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/autoComplete/AutoCompleteService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/autoComplete/AutoCompleteService.java
@@ -1,0 +1,63 @@
+package com.onedrinktoday.backend.domain.autoComplete;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AutoCompleteService {
+
+  private final RedisTemplate<String, String> redisTemplate;
+
+  public void saveAutoCompleteTag(String tag) {
+
+    for (int i = 0; i < tag.length(); i++) {
+      redisTemplate.opsForZSet().add("auto-tags", tag.substring(0, i + 1), 0);
+    }
+
+    redisTemplate.opsForZSet().add("auto-tags", tag + "*", 0);
+  }
+
+  public void saveAutoCompleteDrink(String drink) {
+
+    for (int i = 0; i < drink.length(); i++) {
+      redisTemplate.opsForZSet().add("auto-drinks", drink.substring(0, i + 1), 0);
+    }
+
+    redisTemplate.opsForZSet().add("auto-drinks", drink + "*", 0);
+  }
+
+  public List<String> getAutoCompleteTag(String tag) {
+
+    Long index = redisTemplate.opsForZSet().rank("auto-tags", tag);
+
+    if (index == null) {
+      return Collections.emptyList();
+    }
+
+    Set<String> tags = redisTemplate.opsForZSet().range("auto-tags", index, index + 50);
+
+    return tags.stream()
+        .filter(x -> x.startsWith(tag) && x.endsWith("*"))
+        .map(x -> x.substring(0, x.length()-1)).toList();
+  }
+
+  public List<String> getAutoCompleteDrink(String drink) {
+
+    Long index = redisTemplate.opsForZSet().rank("auto-drinks", drink);
+
+    if (index == null) {
+      return Collections.emptyList();
+    }
+
+    Set<String> drinks = redisTemplate.opsForZSet().range("auto-drinks", index, index + 50);
+
+    return drinks.stream()
+        .filter(x -> x.startsWith(drink) && x.endsWith("*"))
+        .map(x -> x.substring(0, x.length()-1)).toList();
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
@@ -1,6 +1,8 @@
 package com.onedrinktoday.backend.domain.manager.service;
 
 import static com.onedrinktoday.backend.global.exception.ErrorCode.*;
+
+import com.onedrinktoday.backend.domain.autoComplete.AutoCompleteService;
 import com.onedrinktoday.backend.domain.declaration.dto.DeclarationResponse;
 import com.onedrinktoday.backend.domain.declaration.entity.Declaration;
 import com.onedrinktoday.backend.domain.declaration.repository.DeclarationRepository;
@@ -29,6 +31,7 @@ public class ManagerService {
   private final DeclarationRepository declarationRepository;
   private final PostRepository postRepository;
   private final NotificationService notificationService;
+  private final AutoCompleteService autoCompleteService;
 
   @Value("${post.uri}")
   private String postUri;
@@ -59,6 +62,8 @@ public class ManagerService {
     notificationService.approveRegistrationNotification(
         registration.getMember(), registration
     );
+
+    autoCompleteService.saveAutoCompleteDrink(drink.getName());
 
     return DrinkResponse.from(drinkRepository.save(drink));
   }

--- a/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/post/service/PostService.java
@@ -77,7 +77,7 @@ public class PostService {
     List<Tag> tags = saveTags(postRequest.getTag(), post);
 
     notificationService.tagFollowPostNotification(post.getId(), tags);
-    searchService.save(post);
+    searchService.save(post, tags);
 
     return PostResponse.of(post, tags);
   }
@@ -207,7 +207,7 @@ public class PostService {
     List<Tag> updateTag = saveTags(postRequest.getTag(), post);
 
     post = postRepository.save(post);
-    searchService.save(post);
+    searchService.save(post, updateTag);
 
     return PostResponse.of(post, updateTag);
   }

--- a/src/main/java/com/onedrinktoday/backend/domain/search/ElasticSearchRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/search/ElasticSearchRepository.java
@@ -1,0 +1,9 @@
+package com.onedrinktoday.backend.domain.search;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ElasticSearchRepository extends ElasticsearchRepository<PostDocument, Long> {
+
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/search/PostDocument.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/search/PostDocument.java
@@ -1,0 +1,24 @@
+package com.onedrinktoday.backend.domain.search;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+@Getter
+@Setter
+@Builder
+@Setting(settingPath = "/elasticsearch/settings/settings.json", replicas = 0)
+@Mapping(mappingPath = "/elasticsearch/mappings/mappings.json")
+@Document(indexName = "post")
+public class PostDocument {
+
+  @Id
+  private Long id;
+  private String tags;
+  private String drink;
+
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/search/SearchController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/search/SearchController.java
@@ -1,0 +1,40 @@
+package com.onedrinktoday.backend.domain.search;
+
+import com.onedrinktoday.backend.domain.post.dto.PostResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api")
+@RestController
+@RequiredArgsConstructor
+public class SearchController {
+
+  private final SearchService searchService;
+
+  @PostMapping("/search/tags")
+  public ResponseEntity<Page<PostResponse>> searchPostByTag(
+      @PageableDefault Pageable pageable,
+      @RequestBody List<String> tags
+  ) {
+
+    return ResponseEntity.ok(searchService.searchPostByTag(pageable, tags));
+  }
+
+  @PostMapping("/search/drink")
+  public ResponseEntity<Page<PostResponse>> searchPostByDrink(
+      @PageableDefault Pageable pageable,
+      @RequestParam String drink
+  ) {
+
+    return ResponseEntity.ok(searchService.searchPostByDrink(pageable, drink));
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/search/SearchService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/search/SearchService.java
@@ -1,0 +1,101 @@
+package com.onedrinktoday.backend.domain.search;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import com.onedrinktoday.backend.domain.post.dto.PostResponse;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.post.repository.PostRepository;
+import com.onedrinktoday.backend.domain.postTag.repository.PostTagRepository;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+  private final ElasticsearchOperations elasticsearchOperations;
+  private final ElasticSearchRepository elasticSearchRepository;
+  private final PostTagRepository postTagRepository;
+  private final PostRepository postRepository;
+
+  public void save(Post post) {
+
+    List<Tag> tagList = postTagRepository.findTagsByPostId(post.getId());
+
+    String tags = String.join(" ", tagList.stream()
+        .map(t -> StringUtils.trimAllWhitespace(t.getTagName())).toList());
+
+    PostDocument postDocument = PostDocument.builder()
+        .id(post.getId())
+        .tags(tags)
+        .drink(StringUtils.trimAllWhitespace(post.getDrink().getName()))
+        .build();
+
+    elasticSearchRepository.save(postDocument);
+  }
+
+  public void delete(Post post) {
+    elasticSearchRepository.deleteById(post.getId());
+  }
+
+  public Page<PostResponse> searchPostByTag(Pageable pageable, List<String> tagList) {
+
+    String tags = String.join(" ", tagList.stream()
+        .map(StringUtils::trimAllWhitespace).toList());
+
+    Query query = QueryBuilders.match()
+        .query(tags)
+        .field("tags")
+        .operator(Operator.And)
+        .build()._toQuery();
+
+    return getPostResponses(pageable, query);
+  }
+
+  public Page<PostResponse> searchPostByDrink(Pageable pageable, String drink) {
+
+    Query query = QueryBuilders.match()
+        .query(StringUtils.trimAllWhitespace(drink))
+        .field("drink")
+        .build()._toQuery();
+
+    return getPostResponses(pageable, query);
+  }
+
+  private Page<PostResponse> getPostResponses(Pageable pageable, Query query) {
+
+    NativeQuery nativeQuery = new NativeQueryBuilder()
+        .withQuery(query)
+        .withPageable(pageable)
+        .build();
+
+    SearchHits<PostDocument> searchHits =
+        elasticsearchOperations.search(nativeQuery, PostDocument.class);
+
+    List<Post> posts = searchHits.get()
+        .map(s -> postRepository.findById(s.getContent().getId()).orElse(null))
+        .filter(Objects::nonNull).toList();
+
+    List<PostResponse> postResponses = posts.stream()
+        .map(post -> {
+          List<Tag> tags = postTagRepository.findTagsByPostId(post.getId());
+          return PostResponse.of(post, tags);
+        }).toList();
+
+    return new PageImpl<>(postResponses, pageable, searchHits.getTotalHits());
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/global/config/ElasticSearchConfig.java
+++ b/src/main/java/com/onedrinktoday/backend/global/config/ElasticSearchConfig.java
@@ -1,0 +1,71 @@
+package com.onedrinktoday.backend.global.config;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Slf4j
+@Configuration
+@EnableElasticsearchRepositories
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
+
+  @Value("${spring.data.elasticsearch.url}")
+  private String host;
+
+  @Value("${spring.data.elasticsearch.username}")
+  private String username;
+
+  @Value("${spring.data.elasticsearch.password}")
+  private String password;
+
+  @Override
+  public ClientConfiguration clientConfiguration() {
+    return ClientConfiguration.builder()
+        .connectedTo(host)
+        .usingSsl(disableSslVerification(), allHostsValid())
+        .withBasicAuth(username, password)
+        .build();
+  }
+
+  public static SSLContext disableSslVerification() {
+    try {
+      TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
+        public X509Certificate[] getAcceptedIssuers() {
+          return null;
+        }
+
+        public void checkClientTrusted(X509Certificate[] certs, String authType) {
+        }
+
+        public void checkServerTrusted(X509Certificate[] certs, String authType) {
+        }
+      }};
+
+      SSLContext sc = SSLContext.getInstance("SSL");
+      sc.init(null, trustAllCerts, new java.security.SecureRandom());
+      HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+      return sc;
+
+    } catch (NoSuchAlgorithmException | KeyManagementException e) {
+      log.warn(e.getMessage());
+    }
+    return null;
+  }
+
+  public static HostnameVerifier allHostsValid() {
+    HostnameVerifier allHostsValid = (hostname, session) -> true;
+    HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+    return allHostsValid;
+  }
+}

--- a/src/main/resources/elasticsearch/mappings/mappings.json
+++ b/src/main/resources/elasticsearch/mappings/mappings.json
@@ -1,0 +1,12 @@
+{
+  "properties": {
+
+    "tags": {
+      "type": "text"
+    },
+
+    "drink": {
+      "type": "keyword"
+    }
+  }
+}

--- a/src/main/resources/elasticsearch/settings/settings.json
+++ b/src/main/resources/elasticsearch/settings/settings.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "analyzer": {
+      "korean": {
+        "type": "nori"
+      }
+    }
+  }
+}

--- a/src/test/java/com/onedrinktoday/backend/domain/search/SearchServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/search/SearchServiceTest.java
@@ -1,0 +1,54 @@
+package com.onedrinktoday.backend.domain.search;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.onedrinktoday.backend.domain.drink.entity.Drink;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.postTag.repository.PostTagRepository;
+import com.onedrinktoday.backend.domain.tag.entity.Tag;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTest {
+
+  @Mock
+  private PostTagRepository postTagRepository;
+
+  @Mock
+  private ElasticSearchRepository elasticSearchRepository;
+
+  @InjectMocks
+  private SearchService searchService;
+
+  @Test
+  void save() {
+    //given
+    Drink drink = Drink.builder()
+        .id(1L)
+        .name("특산주")
+        .build();
+
+    Post post = Post.builder()
+        .id(1L)
+        .drink(drink)
+        .build();
+
+    List<Tag> tags = List.of(new Tag(1L, "태그"));
+
+    given(postTagRepository.findTagsByPostId(anyLong()))
+        .willReturn(tags);
+
+    given(elasticSearchRepository.save(any(PostDocument.class)))
+        .willReturn(null);
+
+    //when
+    searchService.save(post);
+  }
+}

--- a/src/test/java/com/onedrinktoday/backend/domain/search/SearchServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/search/SearchServiceTest.java
@@ -49,6 +49,6 @@ class SearchServiceTest {
         .willReturn(null);
 
     //when
-    searchService.save(post);
+    searchService.save(post, tags);
   }
 }


### PR DESCRIPTION
### 변경사항
* 검색 기능
  * PostDocument: ES 에 저장될 게시글에 대한 도큐먼트(태그, 특산주 이름 필드를 가짐)
  * 게시글 저장, 수정, 삭제시 ES 에 도큐먼트 생성, 수정, 삭제 연동
  * 태그/특산주 검색어를 통해 ES 에서 관련 도큐먼트 가져오기 -> Post -> PostResponse 변환과정 거쳐 반환
  * 검색의 효율성을 위해 ES 연동시 태그/특산주 이름에서 공백 제거후 저장하고(실제 "서울 특산주" -> ES 저장시 "서울특산주")
     검색시에도 검색창에 입력한 단어에 공백 제거후 실제 검색 진행 
  * 공백을 제외한 태그/특산주 이름이 정확히 일치하는 게시글만 반환

* 자동완성 기능
  * Redis Sorted Set 을 이용해 구현
  * 태그, 특산주 등록시 Redis Sorted Set 에 해당 문자열의 substring 저장 -> Redis 에서 사전순으로 자동 정렬된다.
    (달콤한 태그 등록시 -> '달', "달콤', '달콤한' 3가지를 redis 에 저장)
  * 실제 테이블에 존재하는 태그나 특산주만 반환하기 위해 완전한 단어 뒤에는 * 붙임('달', '달콤', '달콤한*')
  * 검색창을 통해 넘어온 검색어의 일부를 넘겨받아 해당 단어로 시작하며, 뒤에 * 가 붙은 문자열 리스트 반환

* 테스트
  * ES, Redis 연동해야 적절히 확인 가능한 기능으로 SearchService.save() 만 테스트 구현

* ES 서버 실행후 테스트해 주세요.

* ES 관련 yml 파일 수정 있습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트