### PR TITLE
refactor: 특산주 승인 알림 중복 호출 제거

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/registration/service/RegistrationService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/registration/service/RegistrationService.java
@@ -2,7 +2,6 @@ package com.onedrinktoday.backend.domain.registration.service;
 
 import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
-import com.onedrinktoday.backend.domain.notification.service.NotificationService;
 import com.onedrinktoday.backend.domain.region.entity.Region;
 import com.onedrinktoday.backend.domain.region.repository.RegionRepository;
 import com.onedrinktoday.backend.domain.registration.dto.RegistrationRequest;
@@ -23,7 +22,6 @@ public class RegistrationService {
   private final RegistrationRepository registrationRepository;
   private final MemberService memberService;
   private final RegionRepository regionRepository;
-  private final NotificationService notificationService;
 
   public RegistrationResponse register(RegistrationRequest request) {
 
@@ -38,11 +36,6 @@ public class RegistrationService {
     registration.setRegion(region);
 
     Registration savedRegistration = registrationRepository.save(registration);
-
-    notificationService.approveRegistrationNotification(
-        registration.getMember(),
-        savedRegistration
-    );
 
     return RegistrationResponse.from(savedRegistration);
   }


### PR DESCRIPTION
### 변경사항
- ManagerService와 동일한 코드로 인하여 매니저가 특산주를 승인하면 사용자에게 두번 알림이 가게 되는 문제가 발생했습니다.
- RegistrationService에 있는 알림 코드 제거를 하여 매니저가 승인을 하면 신청 회원에게 알림을 한번만 호출되도록 수정

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 