### PR TITLE
feat: 공지사항 기능 구현

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementController.java
@@ -27,7 +27,7 @@ public class AnnouncementController {
   private final AnnouncementService announcementService;
 
   @PreAuthorize("hasRole('MANAGER')")
-  @PostMapping("/announcement")
+  @PostMapping("/announcements")
   public ResponseEntity<AnnouncementResponse> createAnnouncement(
       @RequestBody AnnouncementRequest announcementRequest) {
     return ResponseEntity.ok(announcementService.createAnnouncement(announcementRequest));

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementController.java
@@ -1,0 +1,64 @@
+package com.onedrinktoday.backend.domain.announcement.controller;
+
+import com.onedrinktoday.backend.domain.announcement.dto.AnnouncementRequest;
+import com.onedrinktoday.backend.domain.announcement.dto.AnnouncementResponse;
+import com.onedrinktoday.backend.domain.announcement.service.AnnouncementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AnnouncementController {
+
+  private final AnnouncementService announcementService;
+
+  @PreAuthorize("hasRole('MANAGER')")
+  @PostMapping("/announcement")
+  public ResponseEntity<AnnouncementResponse> createAnnouncement(
+      @RequestBody AnnouncementRequest announcementRequest) {
+    return ResponseEntity.ok(announcementService.createAnnouncement(announcementRequest));
+  }
+
+  @GetMapping("/announcements")
+  public ResponseEntity<Page<AnnouncementResponse>> getAllAnnouncements(
+      @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    Page<AnnouncementResponse> announcements = announcementService.getAllAnnouncements(pageable);
+    return ResponseEntity.ok(announcements);
+  }
+
+  @GetMapping("/announcements/{announcementId}")
+  public ResponseEntity<AnnouncementResponse> getAnnouncement(@PathVariable Long announcementId) {
+    return ResponseEntity.ok(announcementService.getAnnouncement(announcementId));
+  }
+
+  @PreAuthorize("hasRole('MANAGER')")
+  @PutMapping("/announcements/{announcementId}")
+  public ResponseEntity<AnnouncementResponse> updateAnnouncement(
+      @PathVariable Long announcementId,
+      @RequestBody AnnouncementRequest announcementRequest) {
+    return ResponseEntity.ok(
+        announcementService.updateAnnouncement(announcementId, announcementRequest));
+  }
+
+  @PreAuthorize("hasRole('MANAGER')")
+  @DeleteMapping("/announcements/{announcementId}")
+  public ResponseEntity<Void> deleteAnnouncement(@PathVariable Long announcementId) {
+    announcementService.deleteAnnouncement(announcementId);
+    return ResponseEntity.noContent().build();
+  }
+
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementController.java
@@ -56,9 +56,8 @@ public class AnnouncementController {
 
   @PreAuthorize("hasRole('MANAGER')")
   @DeleteMapping("/announcements/{announcementId}")
-  public ResponseEntity<Void> deleteAnnouncement(@PathVariable Long announcementId) {
+  public ResponseEntity<String> deleteAnnouncement(@PathVariable Long announcementId) {
     announcementService.deleteAnnouncement(announcementId);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.ok("공지사항이 정상적으로 삭제되었습니다.");
   }
-
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/dto/AnnouncementRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/dto/AnnouncementRequest.java
@@ -5,15 +5,20 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@Setter
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class AnnouncementRequest {
+
   @Size(min = 2, max = 50)
   private String title;
+
   @Size(min = 10, max = 3000)
   private String content;
+
   private String imageUrl;
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/dto/AnnouncementRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/dto/AnnouncementRequest.java
@@ -1,0 +1,19 @@
+package com.onedrinktoday.backend.domain.announcement.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnnouncementRequest {
+  @Size(min = 2, max = 50)
+  private String title;
+  @Size(min = 10, max = 3000)
+  private String content;
+  private String imageUrl;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/dto/AnnouncementRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/dto/AnnouncementRequest.java
@@ -19,6 +19,4 @@ public class AnnouncementRequest {
 
   @Size(min = 10, max = 3000)
   private String content;
-
-  private String imageUrl;
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/dto/AnnouncementResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/dto/AnnouncementResponse.java
@@ -1,0 +1,33 @@
+package com.onedrinktoday.backend.domain.announcement.dto;
+
+import com.onedrinktoday.backend.domain.announcement.entity.Announcement;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnnouncementResponse {
+
+  private Long id;
+  private Long memberId;
+  private String title;
+  private String content;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public static AnnouncementResponse from(Announcement announcement) {
+    return AnnouncementResponse.builder()
+        .id(announcement.getId())
+        .memberId(announcement.getMember().getId())
+        .title(announcement.getTitle())
+        .content(announcement.getContent())
+        .createdAt(announcement.getCreatedAt())
+        .updatedAt(announcement.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/dto/AnnouncementResponse.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/dto/AnnouncementResponse.java
@@ -17,6 +17,7 @@ public class AnnouncementResponse {
   private Long memberId;
   private String title;
   private String content;
+  private String imageUrl;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
@@ -26,6 +27,7 @@ public class AnnouncementResponse {
         .memberId(announcement.getMember().getId())
         .title(announcement.getTitle())
         .content(announcement.getContent())
+        .imageUrl(announcement.getImageUrl())
         .createdAt(announcement.getCreatedAt())
         .updatedAt(announcement.getUpdatedAt())
         .build();

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/entity/Announcement.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/entity/Announcement.java
@@ -1,0 +1,48 @@
+package com.onedrinktoday.backend.domain.announcement.entity;
+
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Announcement {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @Column(name = "title")
+  private String title;
+
+  @Column(name = "content", columnDefinition = "TEXT", nullable = false)
+  private String content;
+
+  @Column(name = "image_url")
+  private String imageUrl;
+
+  @CreationTimestamp
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/repository/AnnouncementRepository.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/repository/AnnouncementRepository.java
@@ -1,0 +1,10 @@
+package com.onedrinktoday.backend.domain.announcement.repository;
+
+import com.onedrinktoday.backend.domain.announcement.entity.Announcement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +30,6 @@ public class AnnouncementService {
         .member(member)
         .title(announcementRequest.getTitle())
         .content(announcementRequest.getContent())
-        .imageUrl(announcementRequest.getImageUrl())
         .build();
 
     announcement = announcementRepository.save(announcement);
@@ -44,8 +44,7 @@ public class AnnouncementService {
       return Page.empty(pageable);
     }
 
-    return announcementRepository.findAll(pageable)
-        .map(AnnouncementResponse::from);
+    return announcements.map(AnnouncementResponse::from);
   }
 
   public AnnouncementResponse getAnnouncement(Long announcementId) {
@@ -55,6 +54,7 @@ public class AnnouncementService {
     return AnnouncementResponse.from(announcement);
   }
 
+  @Transactional
   public AnnouncementResponse updateAnnouncement(Long announcementId,
       AnnouncementRequest announcementRequest) {
     Member member = memberService.getMember();
@@ -73,6 +73,7 @@ public class AnnouncementService {
     return AnnouncementResponse.from(updatedAnnouncement);
   }
 
+  @Transactional
   public void deleteAnnouncement(Long announcementId) {
     Member member = memberService.getMember();
 
@@ -93,16 +94,13 @@ public class AnnouncementService {
         ? request.getTitle() : announcement.getTitle();
     String updatedContent = (request.getContent() != null && !request.getContent().trim().isEmpty())
         ? request.getContent() : announcement.getContent();
-    String updatedImageUrl =
-        (request.getImageUrl() != null && !request.getImageUrl().trim().isEmpty())
-            ? request.getImageUrl() : announcement.getImageUrl();
 
     return Announcement.builder()
         .id(announcement.getId())
         .member(announcement.getMember())
         .title(updatedTitle)
         .content(updatedContent)
-        .imageUrl(updatedImageUrl)
+        .imageUrl(announcement.getImageUrl())
         .createdAt(announcement.getCreatedAt())
         .updatedAt(announcement.getUpdatedAt())
         .build();

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementService.java
@@ -1,0 +1,95 @@
+package com.onedrinktoday.backend.domain.announcement.service;
+
+import static com.onedrinktoday.backend.global.exception.ErrorCode.ACCESS_DENIED;
+import static com.onedrinktoday.backend.global.exception.ErrorCode.ANNOUNCEMENT_NOT_FOUND;
+
+import com.onedrinktoday.backend.domain.announcement.dto.AnnouncementRequest;
+import com.onedrinktoday.backend.domain.announcement.dto.AnnouncementResponse;
+import com.onedrinktoday.backend.domain.announcement.entity.Announcement;
+import com.onedrinktoday.backend.domain.announcement.repository.AnnouncementRepository;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnnouncementService {
+
+  private final AnnouncementRepository announcementRepository;
+  private final MemberService memberService;
+
+  public AnnouncementResponse createAnnouncement(AnnouncementRequest announcementRequest) {
+    Member member = memberService.getMember();
+
+    Announcement announcement = Announcement.builder()
+        .member(member)
+        .title(announcementRequest.getTitle())
+        .content(announcementRequest.getContent())
+        .imageUrl(announcementRequest.getImageUrl())
+        .build();
+
+    announcement = announcementRepository.save(announcement);
+
+    return AnnouncementResponse.from(announcement);
+  }
+
+  public Page<AnnouncementResponse> getAllAnnouncements(Pageable pageable) {
+    Page<Announcement> announcements = announcementRepository.findAll(pageable);
+
+    if (announcements.isEmpty()) {
+      return Page.empty(pageable);
+    }
+
+    return announcementRepository.findAll(pageable)
+        .map(AnnouncementResponse::from);
+  }
+
+  public AnnouncementResponse getAnnouncement(Long announcementId) {
+    Announcement announcement = announcementRepository.findById(announcementId)
+        .orElseThrow(() -> new CustomException(ANNOUNCEMENT_NOT_FOUND));
+
+    return AnnouncementResponse.from(announcement);
+  }
+
+  public AnnouncementResponse updateAnnouncement(Long announcementId, AnnouncementRequest announcementRequest) {
+    Member member = memberService.getMember();
+
+    Announcement announcement = announcementRepository.findById(announcementId)
+        .orElseThrow(() -> new CustomException(ANNOUNCEMENT_NOT_FOUND));
+
+    if (!announcement.getMember().equals(member)) {
+      throw new CustomException(ACCESS_DENIED);
+    }
+
+    Announcement updatedAnnouncement = Announcement.builder()
+        .id(announcement.getId())
+        .member(announcement.getMember())
+        .title(announcementRequest.getTitle())
+        .content(announcementRequest.getContent())
+        .imageUrl(announcementRequest.getImageUrl())
+        .createdAt(announcement.getCreatedAt())
+        .updatedAt(announcement.getUpdatedAt())
+        .build();
+
+    announcementRepository.save(updatedAnnouncement);
+
+    return AnnouncementResponse.from(updatedAnnouncement);
+  }
+
+  public void deleteAnnouncement(Long announcementId) {
+    Member member = memberService.getMember();
+
+    Announcement announcement = announcementRepository.findById(announcementId)
+        .orElseThrow(() -> new CustomException(ANNOUNCEMENT_NOT_FOUND));
+
+    if (!announcement.getMember().equals(member)) {
+      throw new CustomException(ACCESS_DENIED);
+    }
+
+    announcementRepository.delete(announcement);
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementService.java
@@ -55,7 +55,8 @@ public class AnnouncementService {
     return AnnouncementResponse.from(announcement);
   }
 
-  public AnnouncementResponse updateAnnouncement(Long announcementId, AnnouncementRequest announcementRequest) {
+  public AnnouncementResponse updateAnnouncement(Long announcementId,
+      AnnouncementRequest announcementRequest) {
     Member member = memberService.getMember();
 
     Announcement announcement = announcementRepository.findById(announcementId)
@@ -65,12 +66,27 @@ public class AnnouncementService {
       throw new CustomException(ACCESS_DENIED);
     }
 
+    String updatedTitle =
+        (announcementRequest.getTitle() != null && !announcementRequest.getTitle().trim().isEmpty())
+            ? announcementRequest.getTitle()
+            : announcement.getTitle();
+    String updatedContent =
+        (announcementRequest.getContent() != null && !announcementRequest.getContent().trim()
+            .isEmpty())
+            ? announcementRequest.getContent()
+            : announcement.getContent();
+    String updatedImageUrl =
+        (announcementRequest.getImageUrl() != null && !announcementRequest.getImageUrl().trim()
+            .isEmpty())
+            ? announcementRequest.getImageUrl()
+            : announcement.getImageUrl();
+
     Announcement updatedAnnouncement = Announcement.builder()
         .id(announcement.getId())
         .member(announcement.getMember())
-        .title(announcementRequest.getTitle())
-        .content(announcementRequest.getContent())
-        .imageUrl(announcementRequest.getImageUrl())
+        .title(updatedTitle)
+        .content(updatedContent)
+        .imageUrl(updatedImageUrl)
         .createdAt(announcement.getCreatedAt())
         .updatedAt(announcement.getUpdatedAt())
         .build();

--- a/src/main/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementService.java
@@ -66,30 +66,7 @@ public class AnnouncementService {
       throw new CustomException(ACCESS_DENIED);
     }
 
-    String updatedTitle =
-        (announcementRequest.getTitle() != null && !announcementRequest.getTitle().trim().isEmpty())
-            ? announcementRequest.getTitle()
-            : announcement.getTitle();
-    String updatedContent =
-        (announcementRequest.getContent() != null && !announcementRequest.getContent().trim()
-            .isEmpty())
-            ? announcementRequest.getContent()
-            : announcement.getContent();
-    String updatedImageUrl =
-        (announcementRequest.getImageUrl() != null && !announcementRequest.getImageUrl().trim()
-            .isEmpty())
-            ? announcementRequest.getImageUrl()
-            : announcement.getImageUrl();
-
-    Announcement updatedAnnouncement = Announcement.builder()
-        .id(announcement.getId())
-        .member(announcement.getMember())
-        .title(updatedTitle)
-        .content(updatedContent)
-        .imageUrl(updatedImageUrl)
-        .createdAt(announcement.getCreatedAt())
-        .updatedAt(announcement.getUpdatedAt())
-        .build();
+    Announcement updatedAnnouncement = updateAnnouncementFields(announcement, announcementRequest);
 
     announcementRepository.save(updatedAnnouncement);
 
@@ -107,5 +84,27 @@ public class AnnouncementService {
     }
 
     announcementRepository.delete(announcement);
+  }
+
+  private Announcement updateAnnouncementFields(Announcement announcement,
+      AnnouncementRequest request) {
+
+    String updatedTitle = (request.getTitle() != null && !request.getTitle().trim().isEmpty())
+        ? request.getTitle() : announcement.getTitle();
+    String updatedContent = (request.getContent() != null && !request.getContent().trim().isEmpty())
+        ? request.getContent() : announcement.getContent();
+    String updatedImageUrl =
+        (request.getImageUrl() != null && !request.getImageUrl().trim().isEmpty())
+            ? request.getImageUrl() : announcement.getImageUrl();
+
+    return Announcement.builder()
+        .id(announcement.getId())
+        .member(announcement.getMember())
+        .title(updatedTitle)
+        .content(updatedContent)
+        .imageUrl(updatedImageUrl)
+        .createdAt(announcement.getCreatedAt())
+        .updatedAt(announcement.getUpdatedAt())
+        .build();
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
   TOKEN_NOT_MATCH("Refresh Token 값이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
   INVALID_REFRESH_TOKEN("리프레시 토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
   ACCESS_DENIED("접근이 거부되었습니다.", HttpStatus.FORBIDDEN),
+  ANNOUNCEMENT_NOT_FOUND("공지사항을 찾을수 없습니다.", HttpStatus.NOT_FOUND),
   LINK_NOT_FOUND("링크를 찾을 수가 없습니다.", HttpStatus.NOT_FOUND);
 
   private final String message;

--- a/src/test/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementControllerTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementControllerTest.java
@@ -54,7 +54,6 @@ public class AnnouncementControllerTest {
     announcementRequest = new AnnouncementRequest();
     announcementRequest.setTitle("새로운 공지");
     announcementRequest.setContent("공지 내용입니다.");
-    announcementRequest.setImageUrl("http://image");
 
     announcementResponse = AnnouncementResponse.builder()
         .id(1L)
@@ -138,7 +137,6 @@ public class AnnouncementControllerTest {
     AnnouncementRequest updateRequest = new AnnouncementRequest();
     updateRequest.setTitle("수정된 공지");
     updateRequest.setContent("수정된 내용입니다.");
-    updateRequest.setImageUrl("http://image");
 
     AnnouncementResponse updatedResponse = AnnouncementResponse.builder()
         .id(1L)
@@ -170,7 +168,6 @@ public class AnnouncementControllerTest {
     AnnouncementRequest updateRequest = new AnnouncementRequest();
     updateRequest.setTitle("수정된 공지");
     updateRequest.setContent("수정된 내용입니다.");
-    updateRequest.setImageUrl("http://images");
 
     given(announcementService.updateAnnouncement(eq(1010L), any(AnnouncementRequest.class)))
         .willThrow(new IllegalArgumentException("공지사항을 찾을수 없습니다."));

--- a/src/test/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementControllerTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementControllerTest.java
@@ -1,0 +1,209 @@
+package com.onedrinktoday.backend.domain.announcement.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onedrinktoday.backend.domain.announcement.dto.AnnouncementRequest;
+import com.onedrinktoday.backend.domain.announcement.dto.AnnouncementResponse;
+import com.onedrinktoday.backend.domain.announcement.service.AnnouncementService;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AnnouncementController.class, excludeAutoConfiguration = {
+    SecurityAutoConfiguration.class})
+public class AnnouncementControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private AnnouncementService announcementService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private AnnouncementRequest announcementRequest;
+  private AnnouncementResponse announcementResponse;
+
+  @BeforeEach
+  void setUp() {
+    announcementRequest = new AnnouncementRequest();
+    announcementRequest.setTitle("새로운 공지");
+    announcementRequest.setContent("공지 내용입니다.");
+    announcementRequest.setImageUrl("http://image");
+
+    announcementResponse = AnnouncementResponse.builder()
+        .id(1L)
+        .memberId(1L)
+        .title("새로운 공지")
+        .content("공지 내용입니다.")
+        .imageUrl("http://image")
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("공지사항 생성 성공")
+  void successCreateAnnouncement() throws Exception {
+    //given
+    given(announcementService.createAnnouncement(any(AnnouncementRequest.class)))
+        .willReturn(announcementResponse);
+
+    //when, then
+    mockMvc.perform(post("/api/announcement")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(announcementRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(announcementResponse.getId()))
+        .andExpect(jsonPath("$.title").value(announcementResponse.getTitle()))
+        .andExpect(jsonPath("$.content").value(announcementResponse.getContent()));
+  }
+
+  @Test
+  @DisplayName("공지사항 조회 성공")
+  void successGetAnnouncement() throws Exception {
+    //given
+    given(announcementService.getAnnouncement(eq(1L))).willReturn(announcementResponse);
+
+    //when, then
+    mockMvc.perform(get("/api/announcements/{announcementId}", 1L))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(announcementResponse.getId()))
+        .andExpect(jsonPath("$.title").value(announcementResponse.getTitle()))
+        .andExpect(jsonPath("$.content").value(announcementResponse.getContent()));
+  }
+
+  @Test
+  @DisplayName("공지사항 조회 실패 - 공지사항 존재하지 않음")
+  void failGetAnnouncement() throws Exception {
+    //given
+    given(announcementService.getAnnouncement(eq(1010L)))
+        .willThrow(new IllegalArgumentException("공지사항을 찾을수 없습니다."));
+
+    //when, then
+    mockMvc.perform(get("/api/announcements/{announcementId}", 1010L))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("공지사항을 찾을수 없습니다."));
+  }
+
+  @Test
+  @DisplayName("공지사항 전체 조회 성공")
+  void successGetAllAnnouncements() throws Exception {
+    //given
+    Page<AnnouncementResponse> announcementsPage = new PageImpl<>(Collections.singletonList(announcementResponse),
+        PageRequest.of(0, 10, Sort.by("createdAt").descending()), 1);
+    given(announcementService.getAllAnnouncements(PageRequest.of(0, 10, Sort.by("createdAt").descending())))
+        .willReturn(announcementsPage);
+
+    //when, then
+    mockMvc.perform(get("/api/announcements"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].id").value(announcementResponse.getId()))
+        .andExpect(jsonPath("$.content[0].title").value(announcementResponse.getTitle()))
+        .andExpect(jsonPath("$.content[0].content").value(announcementResponse.getContent()));
+  }
+
+  @Test
+  @DisplayName("공지사항 수정 성공")
+  void successUpdateAnnouncement() throws Exception {
+    //given
+    AnnouncementRequest updateRequest = new AnnouncementRequest();
+    updateRequest.setTitle("수정된 공지");
+    updateRequest.setContent("수정된 내용입니다.");
+    updateRequest.setImageUrl("http://image");
+
+    AnnouncementResponse updatedResponse = AnnouncementResponse.builder()
+        .id(1L)
+        .memberId(1L)
+        .title("수정된 공지")
+        .content("수정된 내용입니다.")
+        .createdAt(announcementResponse.getCreatedAt())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    given(announcementService.updateAnnouncement(eq(1L), any(AnnouncementRequest.class)))
+        .willReturn(updatedResponse);
+
+    //when, then
+    mockMvc.perform(put("/api/announcements/{announcementId}", 1L)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(updatedResponse.getId()))
+        .andExpect(jsonPath("$.title").value(updatedResponse.getTitle()))
+        .andExpect(jsonPath("$.content").value(updatedResponse.getContent()));
+  }
+
+  @Test
+  @DisplayName("공지사항 수정 실패 - 공지사항 존재하지 않음")
+  void failUpdateAnnouncement() throws Exception {
+    //given
+    AnnouncementRequest updateRequest = new AnnouncementRequest();
+    updateRequest.setTitle("수정된 공지");
+    updateRequest.setContent("수정된 내용입니다.");
+    updateRequest.setImageUrl("http://images");
+
+    given(announcementService.updateAnnouncement(eq(1010L), any(AnnouncementRequest.class)))
+        .willThrow(new IllegalArgumentException("공지사항을 찾을수 없습니다."));
+
+    //when, then
+    mockMvc.perform(put("/api/announcements/{announcementId}", 1010L)
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(updateRequest)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("공지사항을 찾을수 없습니다."));
+  }
+
+  @Test
+  @DisplayName("공지사항 삭제 성공")
+  void successDeleteAnnouncement() throws Exception {
+    //given
+    doNothing().when(announcementService).deleteAnnouncement(1L);
+
+    //when,then
+    mockMvc.perform(delete("/api/announcements/{announcementId}", 1L))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("공지사항 삭제 실패 - 공지사항 존재하지 않음")
+  void failDeleteAnnouncement() throws Exception {
+    //given
+    doThrow(new IllegalArgumentException("공지사항을 찾을수 없습니다."))
+        .when(announcementService).deleteAnnouncement(1010L);
+
+    //when, then
+    mockMvc.perform(delete("/api/announcements/{announcementId}", 1010L)
+            .with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.error").value("공지사항을 찾을수 없습니다."));
+  }
+}

--- a/src/test/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementControllerTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/announcement/controller/AnnouncementControllerTest.java
@@ -75,7 +75,7 @@ public class AnnouncementControllerTest {
         .willReturn(announcementResponse);
 
     //when, then
-    mockMvc.perform(post("/api/announcement")
+    mockMvc.perform(post("/api/announcements")
             .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(announcementRequest)))
@@ -116,9 +116,11 @@ public class AnnouncementControllerTest {
   @DisplayName("공지사항 전체 조회 성공")
   void successGetAllAnnouncements() throws Exception {
     //given
-    Page<AnnouncementResponse> announcementsPage = new PageImpl<>(Collections.singletonList(announcementResponse),
+    Page<AnnouncementResponse> announcementsPage = new PageImpl<>(
+        Collections.singletonList(announcementResponse),
         PageRequest.of(0, 10, Sort.by("createdAt").descending()), 1);
-    given(announcementService.getAllAnnouncements(PageRequest.of(0, 10, Sort.by("createdAt").descending())))
+    given(announcementService.getAllAnnouncements(
+        PageRequest.of(0, 10, Sort.by("createdAt").descending())))
         .willReturn(announcementsPage);
 
     //when, then
@@ -190,7 +192,7 @@ public class AnnouncementControllerTest {
 
     //when,then
     mockMvc.perform(delete("/api/announcements/{announcementId}", 1L))
-        .andExpect(status().isNoContent());
+        .andExpect(status().isOk());
   }
 
   @Test

--- a/src/test/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementServiceTest.java
@@ -91,7 +91,7 @@ public class AnnouncementServiceTest {
 
   @Test
   @DisplayName("공지사항 생성 실패 - 사용자 인증 실패, 회원(USER) 불가능")
-  void failCreateAnnouncementDueToAuthentication() {
+  void failCreateAnnouncement() {
     //given
     when(memberService.getMember()).thenThrow(new CustomException(ACCESS_DENIED));
 
@@ -117,7 +117,7 @@ public class AnnouncementServiceTest {
 
   @Test
   @DisplayName("공지사항 조회 실패 - 공지사항 없음")
-  void failGetAnnouncementNotFound() {
+  void failGetAnnouncement() {
     // given
     when(announcementRepository.findById(1L)).thenReturn(Optional.empty());
 
@@ -171,7 +171,7 @@ public class AnnouncementServiceTest {
 
   @Test
   @DisplayName("공지사항 수정 실패 - 공지사항 없음")
-  void failUpdateAnnouncementNotFound() {
+  void failUpdateAnnouncement() {
     //given
     when(memberService.getMember()).thenReturn(member);
     when(announcementRepository.findById(1L)).thenReturn(Optional.empty());
@@ -196,7 +196,7 @@ public class AnnouncementServiceTest {
 
   @Test
   @DisplayName("공지사항 삭제 실패 - 공지사항 없음")
-  void failDeleteAnnouncementNotFound() {
+  void failDeleteAnnouncement() {
     //given
     when(memberService.getMember()).thenReturn(member);
     when(announcementRepository.findById(1L)).thenReturn(Optional.empty());

--- a/src/test/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementServiceTest.java
@@ -1,0 +1,207 @@
+package com.onedrinktoday.backend.domain.announcement.service;
+
+import static com.onedrinktoday.backend.global.exception.ErrorCode.ACCESS_DENIED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.onedrinktoday.backend.domain.announcement.dto.AnnouncementRequest;
+import com.onedrinktoday.backend.domain.announcement.dto.AnnouncementResponse;
+import com.onedrinktoday.backend.domain.announcement.entity.Announcement;
+import com.onedrinktoday.backend.domain.announcement.repository.AnnouncementRepository;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.member.service.MemberService;
+import com.onedrinktoday.backend.global.exception.CustomException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AnnouncementServiceTest {
+
+  @InjectMocks
+  private AnnouncementService announcementService;
+
+  @Mock
+  private MemberService memberService;
+
+  @Mock
+  private AnnouncementRepository announcementRepository;
+
+  private AnnouncementRequest announcementRequest;
+  private Announcement announcement;
+  private Member member;
+
+  @BeforeEach
+  void setUp() {
+    member = Member.builder()
+        .id(1L)
+        .name("John Doe")
+        .build();
+
+    announcement = Announcement.builder()
+        .id(1L)
+        .member(member)
+        .title("공지사항 제목")
+        .content("공지사항 내용입니다.")
+        .imageUrl("http://image")
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    announcementRequest = AnnouncementRequest.builder()
+        .title("공지사항 제목")
+        .content("공지사항 내용입니다.")
+        .imageUrl("http://image")
+        .build();
+  }
+
+  @Test
+  @DisplayName("공지사항 생성 성공")
+  void successCreateAnnouncement() {
+    //given
+    when(memberService.getMember()).thenReturn(member);
+
+    ArgumentCaptor<Announcement> argumentCaptor = ArgumentCaptor.forClass(Announcement.class);
+    when(announcementRepository.save(argumentCaptor.capture()))
+        .thenReturn(announcement);
+
+    //when
+    AnnouncementResponse response = announcementService.createAnnouncement(announcementRequest);
+
+    //then
+    Announcement capturedAnnouncement = argumentCaptor.getValue();
+    assertEquals(announcementRequest.getTitle(), capturedAnnouncement.getTitle());
+    assertEquals(announcementRequest.getContent(), capturedAnnouncement.getContent());
+    assertEquals(announcementRequest.getImageUrl(), capturedAnnouncement.getImageUrl());
+    assertEquals(announcement.getId(), response.getId());
+    assertEquals(announcement.getTitle(), response.getTitle());
+    assertEquals(announcement.getContent(), response.getContent());
+    assertEquals(announcement.getImageUrl(), response.getImageUrl());
+  }
+
+  @Test
+  @DisplayName("공지사항 생성 실패 - 사용자 인증 실패, 회원(USER) 불가능")
+  void failCreateAnnouncementDueToAuthentication() {
+    //given
+    when(memberService.getMember()).thenThrow(new CustomException(ACCESS_DENIED));
+
+    //when, then
+    assertEquals("접근이 거부되었습니다.", ACCESS_DENIED.getMessage());
+  }
+
+  @Test
+  @DisplayName("공지사항 조회 성공")
+  void successGetAnnouncement() {
+    //given
+    when(announcementRepository.findById(1L)).thenReturn(Optional.of(announcement));
+
+    //when
+    AnnouncementResponse response = announcementService.getAnnouncement(1L);
+
+    //then
+    assertEquals(announcement.getId(), response.getId());
+    assertEquals(announcement.getTitle(), response.getTitle());
+    assertEquals(announcement.getContent(), response.getContent());
+    assertEquals(announcement.getImageUrl(), response.getImageUrl());
+  }
+
+  @Test
+  @DisplayName("공지사항 조회 실패 - 공지사항 없음")
+  void failGetAnnouncementNotFound() {
+    // given
+    when(announcementRepository.findById(1L)).thenReturn(Optional.empty());
+
+    //when, then
+    assertThrows(CustomException.class, () -> announcementService.getAnnouncement(1L));
+  }
+
+  @Test
+  @DisplayName("공지사항 수정 성공")
+  void successUpdateAnnouncement() {
+    //given
+    String newTitle = "수정된 공지사항 제목";
+    String newContent = "수정된 공지사항 내용입니다.";
+    String newImageUrl = "http://image";
+
+    AnnouncementRequest updateRequest = AnnouncementRequest.builder()
+        .title(newTitle)
+        .content(newContent)
+        .imageUrl(newImageUrl)
+        .build();
+
+    Announcement updatedAnnouncement = Announcement.builder()
+        .id(1L)
+        .member(member)
+        .title(newTitle)
+        .content(newContent)
+        .imageUrl(newImageUrl)
+        .createdAt(announcement.getCreatedAt())
+        .updatedAt(LocalDateTime.now())
+        .build();
+
+    when(memberService.getMember()).thenReturn(member);
+    when(announcementRepository.findById(1L)).thenReturn(Optional.of(announcement));
+    when(announcementRepository.save(any(Announcement.class))).thenReturn(updatedAnnouncement);
+
+    //when
+    AnnouncementResponse response = announcementService.updateAnnouncement(1L, updateRequest);
+
+    //then
+    ArgumentCaptor<Announcement> argumentCaptor = ArgumentCaptor.forClass(Announcement.class);
+    verify(announcementRepository).save(argumentCaptor.capture());
+    Announcement savedAnnouncement = argumentCaptor.getValue();
+
+    assertEquals(newTitle, savedAnnouncement.getTitle());
+    assertEquals(newContent, savedAnnouncement.getContent());
+    assertEquals(newImageUrl, savedAnnouncement.getImageUrl());
+    assertEquals(newTitle, response.getTitle());
+    assertEquals(newContent, response.getContent());
+    assertEquals(newImageUrl, response.getImageUrl());
+  }
+
+  @Test
+  @DisplayName("공지사항 수정 실패 - 공지사항 없음")
+  void failUpdateAnnouncementNotFound() {
+    //given
+    when(memberService.getMember()).thenReturn(member);
+    when(announcementRepository.findById(1L)).thenReturn(Optional.empty());
+
+    //when, then
+    assertThrows(CustomException.class, () -> announcementService.updateAnnouncement(1L, announcementRequest));
+  }
+
+  @Test
+  @DisplayName("공지사항 삭제 성공")
+  void successDeleteAnnouncement() {
+    //given
+    when(memberService.getMember()).thenReturn(member);
+    when(announcementRepository.findById(1L)).thenReturn(Optional.of(announcement));
+
+    //when
+    announcementService.deleteAnnouncement(1L);
+
+    //then
+    verify(announcementRepository).delete(announcement);
+  }
+
+  @Test
+  @DisplayName("공지사항 삭제 실패 - 공지사항 없음")
+  void failDeleteAnnouncementNotFound() {
+    //given
+    when(memberService.getMember()).thenReturn(member);
+    when(announcementRepository.findById(1L)).thenReturn(Optional.empty());
+
+    //when, then
+    assertThrows(CustomException.class, () -> announcementService.deleteAnnouncement(1L));
+  }
+}

--- a/src/test/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementServiceTest.java
@@ -61,7 +61,6 @@ public class AnnouncementServiceTest {
     announcementRequest = AnnouncementRequest.builder()
         .title("공지사항 제목")
         .content("공지사항 내용입니다.")
-        .imageUrl("http://image")
         .build();
   }
 
@@ -82,7 +81,6 @@ public class AnnouncementServiceTest {
     Announcement capturedAnnouncement = argumentCaptor.getValue();
     assertEquals(announcementRequest.getTitle(), capturedAnnouncement.getTitle());
     assertEquals(announcementRequest.getContent(), capturedAnnouncement.getContent());
-    assertEquals(announcementRequest.getImageUrl(), capturedAnnouncement.getImageUrl());
     assertEquals(announcement.getId(), response.getId());
     assertEquals(announcement.getTitle(), response.getTitle());
     assertEquals(announcement.getContent(), response.getContent());
@@ -96,7 +94,7 @@ public class AnnouncementServiceTest {
     when(memberService.getMember()).thenThrow(new CustomException(ACCESS_DENIED));
 
     //when
-    CustomException exception = assertThrows(CustomException.class, () -> announcementService.createAnnouncement(new AnnouncementRequest("title", "content", "imageUrl")));
+    CustomException exception = assertThrows(CustomException.class, () -> announcementService.createAnnouncement(new AnnouncementRequest("title", "content")));
 
     //then
     assertEquals(ACCESS_DENIED.getMessage(), exception.getMessage());
@@ -134,12 +132,10 @@ public class AnnouncementServiceTest {
     //given
     String newTitle = "수정된 공지사항 제목";
     String newContent = "수정된 공지사항 내용입니다.";
-    String newImageUrl = "http://image";
 
     AnnouncementRequest updateRequest = AnnouncementRequest.builder()
         .title(newTitle)
         .content(newContent)
-        .imageUrl(newImageUrl)
         .build();
 
     Announcement updatedAnnouncement = Announcement.builder()
@@ -147,7 +143,7 @@ public class AnnouncementServiceTest {
         .member(member)
         .title(newTitle)
         .content(newContent)
-        .imageUrl(newImageUrl)
+        .imageUrl(announcement.getImageUrl())
         .createdAt(announcement.getCreatedAt())
         .updatedAt(LocalDateTime.now())
         .build();
@@ -166,10 +162,10 @@ public class AnnouncementServiceTest {
 
     assertEquals(newTitle, savedAnnouncement.getTitle());
     assertEquals(newContent, savedAnnouncement.getContent());
-    assertEquals(newImageUrl, savedAnnouncement.getImageUrl());
+    assertEquals(announcement.getImageUrl(), savedAnnouncement.getImageUrl());
     assertEquals(newTitle, response.getTitle());
     assertEquals(newContent, response.getContent());
-    assertEquals(newImageUrl, response.getImageUrl());
+    assertEquals(announcement.getImageUrl(), response.getImageUrl());
   }
 
   @Test

--- a/src/test/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/announcement/service/AnnouncementServiceTest.java
@@ -90,13 +90,16 @@ public class AnnouncementServiceTest {
   }
 
   @Test
-  @DisplayName("공지사항 생성 실패 - 사용자 인증 실패, 회원(USER) 불가능")
+  @DisplayName("공지사항 생성 실패 - 사용자 인증 실패")
   void failCreateAnnouncement() {
     //given
     when(memberService.getMember()).thenThrow(new CustomException(ACCESS_DENIED));
 
-    //when, then
-    assertEquals("접근이 거부되었습니다.", ACCESS_DENIED.getMessage());
+    //when
+    CustomException exception = assertThrows(CustomException.class, () -> announcementService.createAnnouncement(new AnnouncementRequest("title", "content", "imageUrl")));
+
+    //then
+    assertEquals(ACCESS_DENIED.getMessage(), exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
- Request에 3개의 필드가 다 @Setter이 필요하여 클래스에 붙였습니다.
- Controller
   - 공지사항 생성: 관리자가 새로운 공지사항을 작성할 수 있습니다. 작성자는 AnnouncementRequest를 통해 제목, 내용, 이미지 URL을 입력하여 저장합니다.
   - 공지사항 조회: 모든 사용자가 공지사항 목록을 최신순으로 조회할 수 있습니다. 또한, 특정 공지사항을 ID로 조회하는 기능을 추가하였습니다.
   - 공지사항 수정: 관리자가 기존 공지사항을 수정할 수 있습니다. 인증된 관리자가 작성자와 일치할 경우에만 수정이 가능하며, 수정된 내용은 AnnouncementRequest를 통해 처리됩니다.
   - 공지사항 삭제: 관리자가 특정 공지사항을 삭제할 수 있습니다. 인증된 관리자가 작성자와 일치할 경우에만 삭제가 가능합니다.
- Service
   - 공지사항 생성
     - memberService.getMember()를 통해 현재 로그인한 사용자 정보를 가져옵니다.
     - 공지사항의 제목, 내용을 포함한 새로운 공지사항을 생성합니다.
     - 생성된 공지사항을 데이터베이스에 저장하고, 그 정보를 AnnouncementResponse 형태로 반환합니다.
   - 전체 공지사항 조회
     - 페이지네이션을 지원하여, Pageable을 사용해 요청된 페이지의 공지사항 목록을 가져옵니다.
     - 공지사항이 없을 경우, 빈 페이지를 반환합니다.
     - 조회된 공지사항 목록을 AnnouncementResponse로 변환하여 반환합니다.
   - 단일 공지사항 조회
     - 공지사항 ID를 기준으로 공지사항을 조회합니다.
     - 공지사항이 존재하지 않을 경우, ANNOUNCEMENT_NOT_FOUND 예외를 발생시킵니다.
     - 조회된 공지사항을 AnnouncementResponse로 변환하여 반환합니다.
   -  공지사항 수정
      - 현재 로그인한 사용자 정보를 가져와, 수정하려는 공지사항의 작성자와 일치하는지 확인합니다.
      - 일치하지 않을 경우 ACCESS_DENIED 예외를 발생시킵니다.
      - 작성자가 일치하면, 공지사항의 제목, 내용을 요청값으로 업데이트한 후 저장합니다.
      - 수정된 공지사항 정보를 AnnouncementResponse로 변환하여 반환합니다.
   -  공지사항 삭제
      - 삭제하려는 공지사항의 작성자와 로그인한 사용자를 비교합니다.
      - 작성자가 아니면 ACCESS_DENIED 예외를 발생시킵니다.
      - 작성자가 일치하면, 공지사항을 삭제합니다.
 - Controller test
   -  successCreateAnnouncement: 공지사항 생성 요청이 성공적으로 처리되는지 확인
   -  successGetAnnouncement: 특정 공지사항을 정상적으로 조회할 수 있는지 확인
   -  successGetAllAnnouncements: 모든 공지사항을 페이지네이션을 통해 정상적으로 조회할 수 있는지 확인
   -  successUpdateAnnouncement: 공지사항을 성공적으로 수정할 수 있는지 검증하는지 확인
   -  failUpdateAnnouncement: 존재하지 않는 공지사항을 수정하려 할 때 적절한 에러가 반환되는지 확인
   -  successDeleteAnnouncement: 특정 공지사항을 정상적으로 삭제할 수 있는지 확인
   -  failDeleteAnnouncement: 존재하지 않는 공지사항을 삭제하려 할 때 적절한 에러 메시지와 상태 코드가 반환되는지 확인
- Service test
   -  successCreateAnnouncement: 공지사항을 성공적으로 생성할 수 있는지 확인
   - failCreateAnnouncement: 사용자 인증 실패 시 공지사항 생성이 거부되는지 확인
   - successGetAnnouncement: 특정 공지사항을 정상적으로 조회할 수 있는지 확인
   - failGetAnnouncement: 존재하지 않는 공지사항을 조회하려 할 때 예외가 발생하는지 확인
   - successUpdateAnnouncement: 공지사항을 성공적으로 수정할 수 있는지 확인
   - failUpdateAnnouncement: 존재하지 않는 공지사항을 수정하려 할 때 예외가 발생하는지 확인
   - successDeleteAnnouncement: 공지사항을 성공적으로 삭제할 수 있는지 확인
   - failDeleteAnnouncement: 존재하지 않는 공지사항을 삭제하려 할 때 예외가 발생하는지 확인
   
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 