### PR TITLE
feat: 신고 반려 기능 구현

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/manager/controller/ManagerController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/manager/controller/ManagerController.java
@@ -2,12 +2,14 @@ package com.onedrinktoday.backend.domain.manager.controller;
 
 import com.onedrinktoday.backend.domain.declaration.dto.DeclarationResponse;
 import com.onedrinktoday.backend.domain.drink.dto.DrinkResponse;
+import com.onedrinktoday.backend.domain.manager.dto.cancelDeclarationRequest;
 import com.onedrinktoday.backend.domain.manager.service.ManagerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,9 +41,11 @@ public class ManagerController {
   }
 
   @PutMapping("/manager/declarations/{declarationId}/cancel")
-  public ResponseEntity<DeclarationResponse> cancelDeclaration(@PathVariable Long declarationId) {
+  public ResponseEntity<DeclarationResponse> cancelDeclaration(@PathVariable Long declarationId,
+      @RequestBody cancelDeclarationRequest cancelDeclarationRequest) {
 
-    return ResponseEntity.ok(managerService.cancelDeclaration(declarationId));
+    return ResponseEntity.ok(
+        managerService.cancelDeclaration(declarationId, cancelDeclarationRequest));
   }
 
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/manager/dto/cancelDeclarationRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/manager/dto/cancelDeclarationRequest.java
@@ -1,0 +1,16 @@
+package com.onedrinktoday.backend.domain.manager.dto;
+
+import com.onedrinktoday.backend.global.type.cancelDeclarationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class cancelDeclarationRequest {
+
+  private cancelDeclarationType type;
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/manager/service/ManagerService.java
@@ -9,6 +9,7 @@ import com.onedrinktoday.backend.domain.declaration.repository.DeclarationReposi
 import com.onedrinktoday.backend.domain.drink.dto.DrinkResponse;
 import com.onedrinktoday.backend.domain.drink.entity.Drink;
 import com.onedrinktoday.backend.domain.drink.repository.DrinkRepository;
+import com.onedrinktoday.backend.domain.manager.dto.cancelDeclarationRequest;
 import com.onedrinktoday.backend.domain.notification.service.NotificationService;
 import com.onedrinktoday.backend.domain.post.entity.Post;
 import com.onedrinktoday.backend.domain.post.repository.PostRepository;
@@ -84,17 +85,20 @@ public class ManagerService {
     Post post = postRepository.findById(postIdFromLink(declaration.getLink()))
         .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
 
-    notificationService.postDeclarationNotification(post, declaration);
+    notificationService.approveDeclarationNotification(post, declaration);
 
     declaration.setApproved(true);
 
     return DeclarationResponse.from(declarationRepository.save(declaration));
   }
 
-  public DeclarationResponse cancelDeclaration(Long declarationId) {
+  public DeclarationResponse cancelDeclaration(Long declarationId,
+      cancelDeclarationRequest cancelDeclarationRequest) {
 
     Declaration declaration = declarationRepository.findById(declarationId)
         .orElseThrow(() -> new CustomException(DECLARATION_NOT_FOUND));
+
+    notificationService.cancelDeclarationNotification(declaration, cancelDeclarationRequest);
 
     declaration.setApproved(false);
 

--- a/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import static com.onedrinktoday.backend.global.exception.ErrorCode.*;
 import static com.onedrinktoday.backend.global.type.NotificationType.*;
 
 import com.onedrinktoday.backend.domain.declaration.entity.Declaration;
+import com.onedrinktoday.backend.domain.manager.dto.cancelDeclarationRequest;
 import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
 import com.onedrinktoday.backend.domain.notification.entity.Notification;
@@ -32,6 +33,7 @@ public class NotificationService {
   private final PostRepository postRepository;
   private final TagFollowRepository tagFollowRepository;
 
+  @Async
   public void createNotification(Member member, Long postId, NotificationType type,
       String content) {
     Notification notification = Notification.builder()
@@ -58,7 +60,6 @@ public class NotificationService {
     createNotification(post.getMember(), postId, COMMENT, content);
   }
 
-  @Async
   public void tagFollowPostNotification(Long postId, List<Tag> tags) {
     Post post = postRepository.findById(postId)
         .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
@@ -74,7 +75,7 @@ public class NotificationService {
     }
   }
 
-  public void postDeclarationNotification(Post post, Declaration declaration) {
+  public void approveDeclarationNotification(Post post, Declaration declaration) {
     createNotification(
         post.getMember(),
         post.getId(),
@@ -87,6 +88,18 @@ public class NotificationService {
         null,
         NotificationType.DECLARATION,
         "신고된 게시글이 승인되었습니다."
+    );
+  }
+
+  public void cancelDeclarationNotification(Declaration declaration,
+      cancelDeclarationRequest cancelDeclarationRequest) {
+    String message = "신고 처리 결과를 확인하세요: " + cancelDeclarationRequest.getType().getMessage();
+
+    createNotification(
+        declaration.getMember(),
+        declaration.getId(),
+        NotificationType.REJECTION,
+        message
     );
   }
 

--- a/src/main/java/com/onedrinktoday/backend/global/type/NotificationType.java
+++ b/src/main/java/com/onedrinktoday/backend/global/type/NotificationType.java
@@ -4,6 +4,7 @@ public enum NotificationType {
   FOLLOW,
   COMMENT,
   DECLARATION,
+  REJECTION,
   REGISTRATION,
   REMOVED
 }

--- a/src/main/java/com/onedrinktoday/backend/global/type/cancelDeclarationType.java
+++ b/src/main/java/com/onedrinktoday/backend/global/type/cancelDeclarationType.java
@@ -1,0 +1,16 @@
+package com.onedrinktoday.backend.global.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum cancelDeclarationType {
+  POST_DELETED_BY_USER("신고하신 회원의 게시글을 삭제하여 게시글이 존재하지 않습니다."),
+  NOT_RELEVANT("신고 내용이 게시글과 관련이 없습니다."),
+  MISUNDERSTANDING("신고자가 게시글을 오해하거나 잘못 해석하였습니다."),
+  NOT_ENOUGH_DETAILS("신고 사유에 대한 구체적인 정보나 설명이 부족합니다."),
+  DUPLICATE_REPORT("신고자의 의미없는 반복된 신고입니다.");
+
+  private final String message;
+}

--- a/src/test/java/com/onedrinktoday/backend/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/notification/service/NotificationServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.onedrinktoday.backend.domain.declaration.entity.Declaration;
+import com.onedrinktoday.backend.domain.manager.dto.cancelDeclarationRequest;
 import com.onedrinktoday.backend.domain.member.entity.Member;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
 import com.onedrinktoday.backend.domain.notification.entity.Notification;
@@ -19,6 +20,7 @@ import com.onedrinktoday.backend.domain.tagFollow.entity.TagFollow;
 import com.onedrinktoday.backend.domain.tagFollow.repository.TagFollowRepository;
 import com.onedrinktoday.backend.global.exception.CustomException;
 import com.onedrinktoday.backend.global.type.NotificationType;
+import com.onedrinktoday.backend.global.type.cancelDeclarationType;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -228,7 +230,7 @@ public class NotificationServiceTest {
   void successPostDeclarationNotification() {
     //given
     //when
-    notificationService.postDeclarationNotification(post, declaration);
+    notificationService.approveDeclarationNotification(post, declaration);
 
     //then
     verify(notificationRepository, times(1)).save(argThat(notification ->
@@ -243,6 +245,32 @@ public class NotificationServiceTest {
             notification.getPostId() == null &&
             notification.getType().equals(NotificationType.DECLARATION) &&
             notification.getContent().equals("신고된 게시글이 승인되었습니다.")
+    ));
+  }
+
+  @Test
+  @DisplayName("신고 반려 알림 생성 성공")
+  void successCancelDeclarationNotification() {
+    //given
+    String message = "신고 처리 결과를 확인하세요: " + cancelDeclarationType.POST_DELETED_BY_USER.getMessage();
+    cancelDeclarationRequest request = cancelDeclarationRequest.builder()
+        .type(cancelDeclarationType.POST_DELETED_BY_USER)
+        .build();
+
+    declaration = Declaration.builder()
+        .member(member)
+        .id(1L)
+        .build();
+
+    //when
+    notificationService.cancelDeclarationNotification(declaration, request);
+
+    //then
+    verify(notificationRepository, times(1)).save(argThat(notification ->
+        notification.getMember().equals(declaration.getMember()) &&
+            notification.getPostId().equals(declaration.getId()) &&
+            notification.getType().equals(NotificationType.REJECTION) &&
+            notification.getContent().equals(message)
     ));
   }
 


### PR DESCRIPTION
### 변경사항
- **NotificationType**: 열거형에 사용자가 신고를 반려할 때 사용하는 타입으로 `REJECTION`을 추가하였습니다.
- **cancelDeclarationType**: 매니저가 `select`할 수 있도록 열거형 신고 취소 사유를 작성하였습니다.
- **cancelDeclarationRequest**: 신고 반려 시 `cancelDeclarationType `중 하나를 선택하여 반려 할 수 있도록 `DTO`를 작성하였습니다.
- **Manager Controller & Service**
  - Controller: `@RequestBody cancelDeclarationRequest`가 추가되어, 클라이언트로부터 신고 취소 사유를 담고 있는 열거형 타입을 받을 수 있게 하여 반려 사유를 명확하게 전달할 수 있습니다.
  - Service: 입력한 `cancelDeclarationRequest`를 알림 메서드의 인자로 전달하여 알림을 생성하도록 합니다.
- **NotificationService**: 
  - `cancelDeclarationRequest`의 `type`에서 해당 사유의 메시지를 가져와, 사용자에게 전송할 알림 메시지를 작성합니다.
  -  작성된 메시지와 함께 신고한 회원에게 `REJECTION `타입의 알림을 생성합니다. 이때, 알림은 해당 회원의 ID와 신고 ID를 포함합니다.
  - **NotificationServiceTest**: 신고 반려 알림 생성 로직이 올바르게 작동하는지 확인하여, 올바른 알림이 생성되도록 테스트 하였습니다.
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 