### PR TITLE
멤버, 특산주, 게시글 이미지 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ repositories {
 
 dependencies {
 
+    //s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     //es
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 

--- a/src/main/java/com/onedrinktoday/backend/domain/aws/S3Controller.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/aws/S3Controller.java
@@ -1,0 +1,22 @@
+package com.onedrinktoday.backend.domain.aws;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class S3Controller {
+
+  private final S3Service s3Service;
+
+  @PostMapping("/image")
+  public ResponseEntity<String> uploadImage(@RequestParam("multipartFile") MultipartFile file) {
+    return ResponseEntity.ok(s3Service.uploadAndGetUrl(file));
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/aws/S3Service.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/aws/S3Service.java
@@ -1,0 +1,40 @@
+package com.onedrinktoday.backend.domain.aws;
+
+import static com.onedrinktoday.backend.global.exception.ErrorCode.IMAGE_UPLOAD_FAIL;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.onedrinktoday.backend.global.exception.CustomException;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+  private final AmazonS3 amazonS3;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  public String uploadAndGetUrl(MultipartFile file) {
+
+    String originalFilename = file.getOriginalFilename() + UUID.randomUUID();
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentLength(file.getSize());
+    metadata.setContentType(file.getContentType());
+
+    try {
+      amazonS3.putObject(bucket, originalFilename, file.getInputStream(), metadata);
+    } catch (IOException e) {
+      throw new CustomException(IMAGE_UPLOAD_FAIL);
+    }
+
+    //저장한 이미지 url 받기
+    return amazonS3.getUrl(bucket, originalFilename).toString();
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.onedrinktoday.backend.domain.member.dto.MemberRequest;
 import com.onedrinktoday.backend.domain.member.dto.MemberResponse;
 import com.onedrinktoday.backend.domain.member.dto.PasswordResetDTO;
 import com.onedrinktoday.backend.domain.member.dto.PasswordResetRequest;
+import com.onedrinktoday.backend.domain.member.dto.UpdateProfileRequest;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
 import com.onedrinktoday.backend.global.security.JwtProvider;
 import com.onedrinktoday.backend.global.security.TokenDto;
@@ -101,8 +102,10 @@ public class MemberController {
   }
 
   @PutMapping("/members/profile")
-  public ResponseEntity<MemberResponse> updateMemberProfile(@RequestParam String url) {
-    return ResponseEntity.ok(memberService.updateMemberProfile(url));
+  public ResponseEntity<MemberResponse> updateMemberProfile(
+      @RequestBody UpdateProfileRequest request
+  ) {
+    return ResponseEntity.ok(memberService.updateMemberProfile(request.getUrl()));
   }
 
   @DeleteMapping("/members")

--- a/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -97,6 +98,11 @@ public class MemberController {
       @Valid @RequestBody MemberRequest.UpdateInfo request) {
 
     return ResponseEntity.ok(memberService.updateMemberInfo(request));
+  }
+
+  @PutMapping("/members/profile")
+  public ResponseEntity<MemberResponse> updateMemberProfile(@RequestParam String url) {
+    return ResponseEntity.ok(memberService.updateMemberProfile(url));
   }
 
   @DeleteMapping("/members")

--- a/src/main/java/com/onedrinktoday/backend/domain/member/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/dto/UpdateProfileRequest.java
@@ -1,0 +1,16 @@
+package com.onedrinktoday.backend.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProfileRequest {
+
+  private String url;
+
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/entity/Member.java
@@ -67,6 +67,7 @@ public class Member {
   @Setter
   private boolean alarmEnabled;
 
+  @Setter
   private String imageUrl;
 
   @CreationTimestamp

--- a/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
@@ -212,4 +212,10 @@ public class MemberService {
       registrationRepository.saveAll(registrations);
     }
   }
+
+  public MemberResponse updateMemberProfile(String url) {
+    Member member = getMember();
+    member.setImageUrl(url);
+    return MemberResponse.from(memberRepository.save(member));
+  }
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/registration/controller/RegistrationController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/registration/controller/RegistrationController.java
@@ -3,6 +3,7 @@ package com.onedrinktoday.backend.domain.registration.controller;
 import com.onedrinktoday.backend.domain.registration.dto.RegistrationRequest;
 import com.onedrinktoday.backend.domain.registration.dto.RegistrationResponse;
 import com.onedrinktoday.backend.domain.registration.service.RegistrationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,7 +26,7 @@ public class RegistrationController {
 
   @PostMapping("/drinks/registrations")
   public ResponseEntity<RegistrationResponse> register(
-      @RequestBody RegistrationRequest registrationRequest
+      @Valid @RequestBody RegistrationRequest registrationRequest
   ) {
     return ResponseEntity.ok(registrationService.register(registrationRequest));
   }

--- a/src/main/java/com/onedrinktoday/backend/domain/registration/dto/RegistrationRequest.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/registration/dto/RegistrationRequest.java
@@ -1,6 +1,7 @@
 package com.onedrinktoday.backend.domain.registration.dto;
 
 import com.onedrinktoday.backend.global.type.DrinkType;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,4 +23,6 @@ public class RegistrationRequest {
   private Integer cost;
   @Size(min = 10, max = 500)
   private String description;
+  @NotBlank(message = "특산주 이미지를 업로드해주세요")
+  private String imageUrl;
 }

--- a/src/main/java/com/onedrinktoday/backend/domain/registration/entity/Registration.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/registration/entity/Registration.java
@@ -58,6 +58,7 @@ public class Registration {
         .sweetness(request.getSweetness())
         .cost(request.getCost())
         .description(request.getDescription())
+        .imageUrl(request.getImageUrl())
         .build();
   }
 }

--- a/src/main/java/com/onedrinktoday/backend/global/config/S3Config.java
+++ b/src/main/java/com/onedrinktoday/backend/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.onedrinktoday.backend.global.config;
+
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+  @Value("${cloud.aws.credentials.access-key}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.secret-key}")
+  private String secretKey;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AmazonS3Client amazonS3Client() {
+    BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+    return (AmazonS3Client) AmazonS3ClientBuilder
+        .standard()
+        .withRegion(region)
+        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+        .build();
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/onedrinktoday/backend/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
   INVALID_REFRESH_TOKEN("리프레시 토큰이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
   ACCESS_DENIED("접근이 거부되었습니다.", HttpStatus.FORBIDDEN),
   ANNOUNCEMENT_NOT_FOUND("공지사항을 찾을수 없습니다.", HttpStatus.NOT_FOUND),
+  IMAGE_UPLOAD_FAIL("사진 업로드 실패", HttpStatus.BAD_REQUEST),
   LINK_NOT_FOUND("링크를 찾을 수가 없습니다.", HttpStatus.NOT_FOUND);
 
   private final String message;


### PR DESCRIPTION
### 변경사항
* 이미지 업로드, url 반환(S3Controller, S3Service)
  * 프론트에서 multipartFile 넘겨줌 -> 백엔드에서 받아서 S3 업로드후 url 반환
  * 프론트는 받은 url 로 미리보기 표시 가능, 최종 확인버튼 클릭 시 url을 다시 백엔드로 넘겨줘서 DB 에 저장

* 멤버 프로필 이미지
  * 회원가입시 이미지 업로드X, 마이페이지에서 변경 가능

* 게시글 이미지
  * 게시글 작성시 PostRequest 통해 imageUrl 받기(이미지 올릴때 S3 저장후 프론트에 보내준 url 다시 받는것)
  * 게시글 url 비어있을때는 drink 의 url 을 post-imageUrl 로 세팅

* 특산주 이미지
  * 필수로 지정 필요(없으면 에러)
  * 특산주 등록 신청시 이미지 저장후 url 저장
  * 매니저 승인시 신청 테이블 url 을 그대로 특산주 테이블 url 로 복사

* 테스트를 위해 s3 세팅을 직접 다 하기 번거로울것 같아서 제 aws 시크릿키를 포함한 yml을 디스코드로 공유하겠습니다.
* 프론트와 연동해야 적절한 테스트가 이루어질것 같아서 우선 전달받은 url 로 DB 변경하는 부분만 테스트 완료했습니다.