### PR TITLE
refactor: 댓글 기능 수정과 서비스 로직 수정에 따른 테스트 코드 수정

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/comment/service/CommentService.java
@@ -41,7 +41,11 @@ public class CommentService {
         .build();
 
     commentRepository.save(comment);
-    notificationService.postCommentNotification(post.getId(), member.getName(), commentRequest.isAnonymous());
+
+    if (!post.getMember().getId().equals(member.getId())) {
+      notificationService.postCommentNotification(post.getId(), member.getName(),
+          commentRequest.isAnonymous());
+    }
 
     return CommentResponse.from(comment);
   }

--- a/src/test/java/com/onedrinktoday/backend/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/comment/service/CommentServiceTest.java
@@ -3,8 +3,8 @@ package com.onedrinktoday.backend.domain.comment.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -223,17 +223,13 @@ public class CommentServiceTest {
         .anonymous(isAnonymous)
         .build();
 
-    Comment updatedComment = Comment.builder()
-        .id(comment.getId())
-        .member(member)
-        .post(post)
-        .content(newContent)
-        .anonymous(isAnonymous)
-        .build();
-
     when(memberService.getMember()).thenReturn(member);
     when(commentRepository.findById(comment.getId())).thenReturn(Optional.of(comment));
-    when(commentRepository.save(any(Comment.class))).thenReturn(updatedComment);
+
+    comment.setContent(newContent);
+    comment.setAnonymous(isAnonymous);
+
+    when(commentRepository.save(eq(comment))).thenReturn(comment);
 
     //when
     CommentResponse response = commentService.updateComment(comment.getId(), commentRequest);


### PR DESCRIPTION
### 변경사항
- CommentService: 회원이 작성한 게시글에 게시글을 작성한 본인이 댓글을 작성하면 알림이 전송되지 않게 하였습니다.
- CommentServiceTest
  - 댓글 생성 성공
     - `commentRepository.save(eq(comment))`를 통해 정확한 객체가 저장되는지 확인했습니다.
     - `argThat`을 사용하여 전달된 댓글의 속성이 예상한 값과 일치하는지 체크했습니다.
  - 댓글 수정 성공
     - 댓글 객체의 내용을 업데이트한 후 `commentRepository.save(eq(comment))`를 통해 수정된 댓글이 저장되는지 확인했습니다.
     - `comment.setContent(newContent)`와 `comment.setAnonymous(isAnonymous)`로 수정된 값을 설정하였습니다.
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 