### PR TITLE
feat: 사용자 위치 기반 특산주 추천 기능 추가

### DIFF
--- a/src/main/java/com/onedrinktoday/backend/domain/suggest/controller/SuggestController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/suggest/controller/SuggestController.java
@@ -7,6 +7,7 @@ import com.onedrinktoday.backend.domain.suggest.service.SuggestMonthlyService;
 import com.onedrinktoday.backend.domain.suggest.service.SuggestService;
 import com.onedrinktoday.backend.domain.suggest.service.SuggestTagService;
 import com.onedrinktoday.backend.domain.tag.dto.TagDTO;
+import com.onedrinktoday.backend.global.security.JwtProvider;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,17 +27,27 @@ public class SuggestController {
   private final SuggestMonthlyService suggestMonthlyService;
   private final SuggestTagService suggestTagService;
   private final SuggestDrinkService suggestDrinkService;
+  private final JwtProvider jwtProvider;
 
   // 사용자 위치 기반 가장 가까운 지역 특산주 추천
   @GetMapping("/suggest/drink")
-  public ResponseEntity<DrinkResponse> suggestDrink(@RequestHeader("memberId") Long memberId, @RequestParam Float lat, @RequestParam Float lon) {
-    DrinkResponse suggestDrink = suggestService.suggestDrinkByLocation(memberId, lat, lon);
+  public ResponseEntity<DrinkResponse> suggestDrink(
+      @RequestHeader("Access-Token") String token,
+      @RequestParam Float lat,
+      @RequestParam Float lon) {
+
+      Long memberId = jwtProvider.getMemberId(token);
+
+      DrinkResponse suggestDrink = suggestService.suggestDrinkByLocation(memberId, lat, lon);
     return ResponseEntity.ok(suggestDrink);
   }
 
   // 재접속시 기존 사용자의 저장된 지역 특산주 추천
   @GetMapping("/suggest/drink/current")
-  public ResponseEntity<DrinkResponse> suggestDrinkForCurrent(@RequestHeader("memberId") Long memberId) {
+  public ResponseEntity<DrinkResponse> suggestDrinkForCurrent(@RequestHeader("Access-Token") String token) {
+
+    Long memberId = jwtProvider.getMemberId(token);
+
     DrinkResponse suggestDrink = suggestService.suggestDrinkByCurrentRegion(memberId);
     return ResponseEntity.ok(suggestDrink);
   }

--- a/src/main/java/com/onedrinktoday/backend/domain/suggest/controller/SuggestController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/suggest/controller/SuggestController.java
@@ -12,6 +12,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,9 +27,17 @@ public class SuggestController {
   private final SuggestTagService suggestTagService;
   private final SuggestDrinkService suggestDrinkService;
 
+  // 사용자 위치 기반 가장 가까운 지역 특산주 추천
   @GetMapping("/suggest/drink")
-  public ResponseEntity<DrinkResponse> suggestDrink(@RequestParam Float lat, @RequestParam Float lon) {
-    DrinkResponse suggestDrink = suggestService.suggestDrinkByLocation(lat, lon);
+  public ResponseEntity<DrinkResponse> suggestDrink(@RequestHeader("memberId") Long memberId, @RequestParam Float lat, @RequestParam Float lon) {
+    DrinkResponse suggestDrink = suggestService.suggestDrinkByLocation(memberId, lat, lon);
+    return ResponseEntity.ok(suggestDrink);
+  }
+
+  // 재접속시 기존 사용자의 저장된 지역 특산주 추천
+  @GetMapping("/suggest/drink/current")
+  public ResponseEntity<DrinkResponse> suggestDrinkForCurrent(@RequestHeader("memberId") Long memberId) {
+    DrinkResponse suggestDrink = suggestService.suggestDrinkByCurrentRegion(memberId);
     return ResponseEntity.ok(suggestDrink);
   }
 

--- a/src/test/java/com/onedrinktoday/backend/domain/suggest/SuggestServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/suggest/SuggestServiceTest.java
@@ -1,0 +1,93 @@
+package com.onedrinktoday.backend.domain.suggest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.onedrinktoday.backend.domain.drink.dto.DrinkResponse;
+import com.onedrinktoday.backend.domain.drink.entity.Drink;
+import com.onedrinktoday.backend.domain.drink.repository.DrinkRepository;
+import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.member.repository.MemberRepository;
+import com.onedrinktoday.backend.domain.region.entity.Region;
+import com.onedrinktoday.backend.domain.region.repository.RegionRepository;
+import com.onedrinktoday.backend.domain.suggest.service.SuggestService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SuggestServiceTest {
+
+  @Mock
+  private RegionRepository regionRepository;
+
+  @Mock
+  private DrinkRepository drinkRepository;
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @InjectMocks
+  private SuggestService suggestService;
+
+  @Test
+  void suggestDrinkByLocation() {
+    // given
+    Long memberId = 1L;
+    float latitude = 37.5665f; // 서울의 위도
+    float longitude = 126.9780f; // 서울의 경도
+
+    Member member = Member.builder().id(memberId).build();
+
+    Region seoul = Region.builder().id(1L).placeName("서울").latitude(37.5665).longitude(126.9780).build();
+    Region busan = Region.builder().id(2L).placeName("부산").latitude(35.1796).longitude(129.0756).build();
+    List<Region> regions = List.of(seoul, busan);
+
+    Drink drink = Drink.builder().id(1L).region(seoul).name("서울 특산주").build();
+    List<Drink> drinks = List.of(drink);
+
+    // Mock 리턴값 설정
+    given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
+    given(regionRepository.findAll()).willReturn(regions);
+    given(drinkRepository.findByRegion(any(Region.class))).willReturn(drinks);
+
+    // when
+    DrinkResponse result = suggestService.suggestDrinkByLocation(memberId, latitude, longitude);
+
+    // then
+    assertNotNull(result);
+    assertEquals("서울", result.getPlaceName());
+    assertEquals("서울 특산주", result.getName());
+  }
+
+  @Test
+  void suggestDrinkForCurrentRegion() {
+    // given
+    Long memberId = 1L;
+
+    Region seoul = Region.builder().id(1L).placeName("서울").latitude(37.5665).longitude(126.9780).build();
+    Drink drink = Drink.builder().id(1L).region(seoul).name("서울 특산주").build();
+    List<Drink> drinks = List.of(drink);
+
+    Member member = Member.builder().id(memberId).region(seoul).build();
+
+    // Mock 리턴값 설정
+    given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
+    given(drinkRepository.findByRegion(any(Region.class))).willReturn(drinks);
+
+    // when
+    DrinkResponse result = suggestService.suggestDrinkByCurrentRegion(memberId);
+
+    // then
+    assertNotNull(result);
+    assertEquals("서울", result.getPlaceName());
+    assertEquals("서울 특산주", result.getName());
+  }
+}


### PR DESCRIPTION
### 변경사항
- 사용자 위치 기반 가장 가까운 지역 특산주 추천
  - `suggestDrinkByLocation(Long memberId, Float latitude, Float longitude)` : latitude(위도)와 longitude(경도)를 입력받아, 사용자의 현재 위치를 기반으로 가장 가까운 지역을 찾아 특산주를 추천하는 메서드
  - 해당 지역의 특산주 리스트에서 랜덤으로 하나 선택해 반환
  - 사용자의 Member 엔티티의 region_id(거주지) 값을 업데이트하여, 이후 동일한 지역의 특산주를 계속 추천받을 수 있도록 처리

- 사용자가 다시 홈 화면 접속시 이미 저장된 사용자의 거주지 위치값을 기반으로 특산주를 보여줌
  - `suggestDrinkForCurrentRegion(Long memberId)` : 사용자의 region_id 값을 기반으로 현재 설정된 지역의 특산주를 추천하는 메서드
  - 만약, 사용자가 위치 갱신 버튼을 클릭하지 않은 경우, 이 메서드로 기존에 설정된 지역의 특산주를 추천받음

- 사용자 거주지값 갱신 코드 추가

- SuggestServiceTest 테스트 코드 작성
  - `memberRepository.findById(memberId)`를 통해 사용자를 조회 후 Mock 데이터로 사용자 존재 확인
  - `regionRepository.findAll()`을 통해 모든 지역 가져오고, latitude와 longitude 값을 이용해 가장 가까운 지역을 찾아냄
  - `drinkRepository.findByRegion(Region region)`을 통해 해당 지역의 특산주 리스트에서 무작위로 한 개의 특산주를 추천하는지 검증

### 테스트
- [x] 테스트 코드
- [x] API 테스트 