### PR TITLE
test: 매니저 테스트 코드 수정

### DIFF
--- a/src/test/java/com/onedrinktoday/backend/domain/manager/service/ManagerServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/manager/service/ManagerServiceTest.java
@@ -1,24 +1,41 @@
 package com.onedrinktoday.backend.domain.manager.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 
+import com.onedrinktoday.backend.domain.autoComplete.AutoCompleteService;
+import com.onedrinktoday.backend.domain.declaration.dto.DeclarationResponse;
+import com.onedrinktoday.backend.domain.declaration.entity.Declaration;
+import com.onedrinktoday.backend.domain.declaration.repository.DeclarationRepository;
 import com.onedrinktoday.backend.domain.drink.dto.DrinkResponse;
 import com.onedrinktoday.backend.domain.drink.entity.Drink;
 import com.onedrinktoday.backend.domain.drink.repository.DrinkRepository;
+import com.onedrinktoday.backend.domain.manager.dto.CancelDeclarationRequest;
 import com.onedrinktoday.backend.domain.member.entity.Member;
+import com.onedrinktoday.backend.domain.notification.service.NotificationService;
+import com.onedrinktoday.backend.domain.post.entity.Post;
+import com.onedrinktoday.backend.domain.post.repository.PostRepository;
 import com.onedrinktoday.backend.domain.region.entity.Region;
 import com.onedrinktoday.backend.domain.registration.entity.Registration;
 import com.onedrinktoday.backend.domain.registration.repository.RegistrationRepository;
+import com.onedrinktoday.backend.global.type.CancelDeclarationType;
+import com.onedrinktoday.backend.global.type.DeclarationType;
 import com.onedrinktoday.backend.global.type.DrinkType;
+import java.time.LocalDateTime;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ManagerServiceTest {
@@ -29,15 +46,38 @@ class ManagerServiceTest {
   @Mock
   private RegistrationRepository registrationRepository;
 
+  @Mock
+  private PostRepository postRepository;
+
+  @Mock
+  private DeclarationRepository declarationRepository;
+
+  @Mock
+  private NotificationService notificationService;
+
+  @Mock
+  private AutoCompleteService autoCompleteService;
+
   @InjectMocks
   private ManagerService managerService;
 
-  @Test
-  void approveRegistration() {
-    //given
-    Registration registration = Registration.builder()
+  private Declaration declaration;
+  private Registration registration;
+  private Post post;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(managerService, "postUri", "/posts/{postId}");
+    ReflectionTestUtils.setField(managerService, "postId", "postId");
+
+    Member member = Member.builder()
         .id(1L)
-        .member(new Member())
+        .name("John Doe")
+        .build();
+
+    registration = Registration.builder()
+        .id(1L)
+        .member(member)
         .region(new Region())
         .drinkName("특산주")
         .type(DrinkType.BEER)
@@ -47,9 +87,31 @@ class ManagerServiceTest {
         .description("특산주입니다.")
         .build();
 
+    declaration = Declaration.builder()
+        .id(1L)
+        .member(member)
+        .link("/posts/1")
+        .type(DeclarationType.OBSCENE)
+        .content("신고내용 입니다.")
+        .approved(false)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    post = Post.builder()
+        .id(1L)
+        .build();
+  }
+
+  @Test
+  @DisplayName("특산주 승인 성공")
+  void approveRegistration() {
+    //given
+    given(registrationRepository.findById(1L)).willReturn(Optional.of(registration));
+    given(registrationRepository.save(registration)).willReturn(registration);
+
     Drink drink = Drink.builder()
         .id(1L)
-        .region(new Region())
+        .region(registration.getRegion())
         .name("특산주")
         .type(DrinkType.BEER)
         .degree(1.1f)
@@ -58,14 +120,15 @@ class ManagerServiceTest {
         .description("특산주입니다.")
         .build();
 
-    given(registrationRepository.findById(anyLong()))
-        .willReturn(Optional.of(registration));
+    given(drinkRepository.save(argThat(savedDrink ->
+        savedDrink.getName().equals("특산주") &&
+            savedDrink.getRegion().equals(registration.getRegion()) &&
+            savedDrink.getType() == DrinkType.BEER
+    ))).willReturn(drink);
 
-    given(registrationRepository.save(any(Registration.class)))
-        .willReturn(registration);
-
-    given(drinkRepository.save(any(Drink.class)))
-        .willReturn(drink);
+    doNothing().when(notificationService)
+        .approveRegistrationNotification(eq(registration.getMember()), eq(registration));
+    doNothing().when(autoCompleteService).saveAutoCompleteDrink(eq(drink.getName()));
 
     //when
     DrinkResponse drinkResponse = managerService.approveRegistration(1L);
@@ -75,25 +138,11 @@ class ManagerServiceTest {
   }
 
   @Test
+  @DisplayName("특산주 반려 성공")
   void cancelRegistration() {
     //given
-    Registration registration = Registration.builder()
-        .id(1L)
-        .member(new Member())
-        .region(new Region())
-        .drinkName("특산주")
-        .type(DrinkType.BEER)
-        .degree(1.1f)
-        .sweetness(1)
-        .cost(1000)
-        .description("특산주입니다.")
-        .build();
-
-    given(registrationRepository.findById(anyLong()))
-        .willReturn(Optional.of(registration));
-
-    given(registrationRepository.save(any(Registration.class)))
-        .willReturn(registration);
+    given(registrationRepository.findById(1L)).willReturn(Optional.of(registration));
+    given(registrationRepository.save(eq(registration))).willReturn(registration);
 
     //when
     managerService.cancelRegistration(1L);
@@ -101,6 +150,50 @@ class ManagerServiceTest {
     assert true;
   }
 
+  @Test
+  @DisplayName("신고 승인 성공")
+  void approveDeclaration() {
+    //given
+    given(declarationRepository.findById(1L)).willReturn(Optional.of(declaration));
+    given(postRepository.findById(1L)).willReturn(Optional.of(post));
+    doNothing().when(notificationService).approveDeclarationNotification(eq(post), eq(declaration));
 
+    given(declarationRepository.save(eq(declaration))).willAnswer(invocation -> {
+      Declaration savedDeclaration = invocation.getArgument(0);
+      savedDeclaration.setApproved(true);
+      return savedDeclaration;
+    });
 
+    //when
+    DeclarationResponse declarationResponse = managerService.approveDeclaration(1L);
+
+    //then
+    assertEquals(declaration.getId(), declarationResponse.getId());
+    assertTrue(declarationResponse.getApproved());
+    assertTrue(declaration.getApproved());
+  }
+
+  @Test
+  @DisplayName("신고 반려 성공")
+  void cancelDeclaration() {
+    //given
+    CancelDeclarationRequest cancelDeclarationRequest = CancelDeclarationRequest.builder()
+        .type(CancelDeclarationType.POST_DELETED_BY_USER)
+        .build();
+
+    declaration.setApproved(true);
+
+    given(declarationRepository.findById(1L)).willReturn(Optional.of(declaration));
+    doNothing().when(notificationService)
+        .cancelDeclarationNotification(eq(declaration), eq(cancelDeclarationRequest));
+    given(declarationRepository.save(eq(declaration))).willReturn(declaration);
+
+    //when
+    DeclarationResponse declarationResponse = managerService.cancelDeclaration(1L,
+        cancelDeclarationRequest);
+
+    //then
+    assertEquals(declaration.getId(), declarationResponse.getId());
+    assertFalse(declarationResponse.getApproved());
+  }
 }


### PR DESCRIPTION
### 변경사항
- 신고 승인에 필요한 URI와 ID 값을 주입하기 위해 `ManagerService`의 `postUri`와 `postId `필드를 설정하였습니다.
  - `ReflectionTestUtils.setField(managerService, "postUri", "/posts/{postId}");`
  - `ReflectionTestUtils.setField(managerService, "postId", "postId");`
- 기존 테스트 코드 오류를 해결하고 `any()`를 사용하는 대신 `eq()`를 사용하여 명시적으로 비교했습니다. 
- **신고 승인 성공 테스트**
  - 신고 객체와 포스트 객체를 찾고, 승인 알림을 보내며, 신고를 저장할 때 승인 상태를 `true`로 설정합니다.
  - 승인 후 반환된 응답의 ID와 승인 상태를 확인하였습니다.
- **신고 반려 성공 테스트**
  - 신고 반려 요청을 생성하고, 승인된 신고를 반환하도록 설정합니다.
  - 반려 후 반환된 응답의 ID와 승인 상태가 `false`인지 확인하였습니다.
 
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [ ] API 테스트 