### PR TITLE
test: 특산주 서비스 테스트 수정

### DIFF
--- a/src/test/java/com/onedrinktoday/backend/domain/registration/service/RegistrationServiceTest.java
+++ b/src/test/java/com/onedrinktoday/backend/domain/registration/service/RegistrationServiceTest.java
@@ -1,8 +1,7 @@
 package com.onedrinktoday.backend.domain.registration.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 import com.onedrinktoday.backend.domain.member.entity.Member;
@@ -17,6 +16,7 @@ import com.onedrinktoday.backend.global.type.Role;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -55,15 +55,18 @@ class RegistrationServiceTest {
     RegistrationRequest request = RegistrationRequest.builder()
         .drinkName("특산주")
         .description("특산주 입니다.")
+        .regionId(1L)
         .build();
 
     given(memberService.getMember())
         .willReturn(member);
 
-    given(regionRepository.findById(anyLong()))
+    given(regionRepository.findById(eq(1L)))
         .willReturn(Optional.of(region));
 
-    given(registrationRepository.save(any(Registration.class)))
+    ArgumentCaptor<Registration> registrationCaptor = ArgumentCaptor.forClass(Registration.class);
+
+    given(registrationRepository.save(registrationCaptor.capture()))
         .willReturn(Registration.builder()
             .id(1L)
             .member(member)
@@ -78,7 +81,6 @@ class RegistrationServiceTest {
 
     //then
     assertEquals(response.getDrinkName(), "특산주");
-
-
+    assertEquals(registrationCaptor.getValue().getDrinkName(), "특산주");
   }
 }


### PR DESCRIPTION
### 변경사항
- **기존 코드에서 발생하던 오류**
  - `regionRepository.findById(null)` 호출 시 `findById(0L)`로 잘못된 인자를 전달하여` Strict stubbing argument mismatch` 오류가 발생했습니다.
  - 오류 해결을 위해 `RegistrationRequest`에서 `regionId(1L)`을 명시해줌으로써 `findById(null)` 대신 `findById(1L)`로 올바르게 호출되도록 수정하였습니다.
- `findById(anyLong())`를 `findById(eq(1L)`로 변경하여 1L이라는 특정 ID로 findById()가 호출되는 상황을 테스트하는 방식으로 개선하였습니다.
- `registrationRepository.save(any(Registration.class))` 호출 시 `any()`를 사용하던 부분을 `ArgumentCaptor`로 변경하여 `Registration` 객체를 캡처하고 검증하도록 수정했습니다.
- 캡처한 `Registration`객체의 `drinkName`을 검증하도록 추가했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [ ] API 테스트 