### PR TITLE
feat: 비밀번호 재설정 이메일 전송 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/controller/MemberController.java
@@ -3,7 +3,6 @@ package com.onedrinktoday.backend.domain.member.controller;
 import com.onedrinktoday.backend.domain.member.dto.ChangePasswordRequestDTO;
 import com.onedrinktoday.backend.domain.member.dto.MemberRequest;
 import com.onedrinktoday.backend.domain.member.dto.MemberResponse;
-import com.onedrinktoday.backend.domain.member.dto.PasswordResetDTO;
 import com.onedrinktoday.backend.domain.member.dto.PasswordResetRequest;
 import com.onedrinktoday.backend.domain.member.dto.UpdateProfileRequest;
 import com.onedrinktoday.backend.domain.member.service.MemberService;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -52,20 +50,6 @@ public class MemberController {
   @PostMapping("/members/request-password-reset")
   public ResponseEntity<Void> requestPasswordReset(@Valid @RequestBody PasswordResetRequest request) {
     memberService.requestPasswordReset(request.getEmail());
-    return ResponseEntity.ok().build();
-  }
-
-  // 비밀번호 재설정 페이지로 리디렉션(비밀번호 모를 경우)
-  @GetMapping("/members/password-reset")
-  public ResponseEntity<String> showResetPasswordPage(@RequestParam String token) {
-    // 실제로 HTML 템플릿을 렌더링, 프론트엔드 통합테스트 전에 예시로 텍스트+토큰 반환
-    return ResponseEntity.ok("비밀번호 재설정 페이지. 토큰: " + token);
-  }
-
-  // 비밀번호 모를 경우 재설정
-  @PostMapping("/members/password-reset")
-  public ResponseEntity<Void> resetPassword(@Valid @RequestBody PasswordResetDTO request) {
-    memberService.resetPassword(request.getToken(), request.getNewPassword());
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/com/onedrinktoday/backend/domain/member/controller/PasswordResetController.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/controller/PasswordResetController.java
@@ -1,0 +1,53 @@
+package com.onedrinktoday.backend.domain.member.controller;
+
+import com.onedrinktoday.backend.domain.member.dto.PasswordResetDTO;
+import com.onedrinktoday.backend.domain.member.service.MemberService;
+import jakarta.validation.Valid;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class PasswordResetController {
+
+  private final MemberService memberService;
+
+  // 비밀번호 재설정 페이지 렌더링
+  @GetMapping("/members/password-reset")
+  public String showResetPasswordPage(@RequestParam("token") String token, Model model) {
+    model.addAttribute("token", token);
+    return "passwordReset";
+  }
+
+  // 비밀번호 재설정
+  @PostMapping("/members/password-reset")
+  public String resetPassword(@Valid @ModelAttribute PasswordResetDTO request, BindingResult bindingResult, Model model) {
+    if (bindingResult.hasErrors()) {
+      String errorMessage = Objects.requireNonNull(bindingResult.getFieldError("newPassword")).getDefaultMessage();
+      model.addAttribute("error", errorMessage);  // 에러 메시지 추가
+      model.addAttribute("token", request.getToken());
+      return "passwordReset";  // 에러 메시지와 함께 비밀번호 재설정 페이지 다시 렌더링
+    }
+
+    // 비밀번호 변경
+    memberService.resetPassword(request.getToken(), request.getNewPassword());
+
+    // 비밀번호 변경 성공 후 성공 페이지로 리디렉션
+    return "redirect:/api/members/password-reset-success";
+  }
+
+  // 비밀번호 재설정 성공 페이지 렌더링
+  @GetMapping("/members/password-reset-success")
+  public String showPasswordResetSuccessPage() {
+    return "passwordResetSuccess";  // 성공 페이지 템플릿 반환
+  }
+}

--- a/src/main/java/com/onedrinktoday/backend/domain/member/dto/PasswordResetDTO.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/dto/PasswordResetDTO.java
@@ -3,13 +3,12 @@ package com.onedrinktoday.backend.domain.member.dto;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Builder
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class PasswordResetDTO {

--- a/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/onedrinktoday/backend/domain/member/service/MemberService.java
@@ -157,13 +157,14 @@ public class MemberService {
         member.getRole());
 
     // 도메인 변경(예정)
-    String resetLink = "http://localhost:8080/api/members/reset-password?token=" + token;
+    String resetLink = "http://localhost:8080/api/members/password-reset?token=" + token;
 
     emailService.sendPasswordResetEmail(member.getEmail(), resetLink);
   }
 
   // 비밀번호 재설정(회원이 비밀번호를 모를 경우)
   public void resetPassword(String token, String newPassword) {
+
     String email = jwtProvider.getEmail(token);
 
     Member member = memberRepository.findByEmail(email)

--- a/src/main/java/com/onedrinktoday/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/onedrinktoday/backend/global/config/SecurityConfig.java
@@ -29,8 +29,11 @@ public class SecurityConfig {
 
     http
         .authorizeHttpRequests((auth) -> auth
-            .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+            .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**", "/api/members/signin", "/api/members/signup").permitAll()
             .requestMatchers(AntPathRequestMatcher.antMatcher("/api/members/refresh")).permitAll()
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/api/members/request-password-reset")).permitAll()
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/api/members/password-reset")).permitAll()
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/api/members/password-reset-success")).permitAll()
             .anyRequest().authenticated()
         );
 

--- a/src/main/resources/templates/passwordReset.html
+++ b/src/main/resources/templates/passwordReset.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>비밀번호 재설정</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f7f7f7;
+      margin: 0;
+      padding: 0;
+    }
+    .container {
+      width: 100%;
+      max-width: 400px;
+      margin: 50px auto;
+      background-color: #ffffff;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 20px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    }
+    h2 {
+      text-align: center;
+      color: #333;
+    }
+    form {
+      display: flex;
+      flex-direction: column;
+    }
+    label {
+      margin-bottom: 8px;
+      font-weight: bold;
+    }
+    input[type="password"], input[type="text"] {
+      padding: 10px;
+      margin-bottom: 20px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 16px;
+    }
+    .error {
+      color: red;
+      margin-bottom: 20px;
+      text-align: center;
+    }
+    button {
+      padding: 10px;
+      background-color: #FFD18C;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 16px;
+    }
+    button:hover {
+      background-color: #ffbe58;
+    }
+  </style>
+</head>
+<body>
+
+<div class="container">
+  <h2>비밀번호 재설정</h2>
+
+  <!-- 에러 메시지 표시 -->
+  <div th:if="${error}" class="error">
+    <p th:text="${error}"></p>
+  </div>
+
+  <form id="reset-password-form" action="/api/members/password-reset" method="POST">
+    <input type="hidden" id="token" name="token" value="${token}">
+
+    <label for="newPassword">새 비밀번호</label>
+    <input type="password" id="newPassword" name="newPassword" required placeholder="새 비밀번호를 입력하세요.">
+
+    <label for="confirmPassword">비밀번호 확인</label>
+    <input type="password" id="confirmPassword" name="confirmPassword" required placeholder="비밀번호를 다시 입력하세요.">
+
+    <button type="submit">비밀번호 재설정</button>
+  </form>
+</div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    // URL에서 토큰 추출
+    const urlParams = new URLSearchParams(window.location.search);
+    const token = urlParams.get('token');
+
+    // 토큰이 존재하면 숨겨진 input에 토큰 값 설정
+    if (token) {
+      document.getElementById('token').value = token;
+    }
+
+    // 폼 제출 시 비밀번호 확인
+    const form = document.getElementById('reset-password-form');
+    form.addEventListener('submit', function(event) {
+      const newPassword = document.getElementById('newPassword').value;
+      const confirmPassword = document.getElementById('confirmPassword').value;
+
+      // 비밀번호와 비밀번호 확인이 일치하지 않으면 제출하지 않음
+      if (newPassword !== confirmPassword) {
+        event.preventDefault();
+        document.getElementById('error-message').innerText = "비밀번호가 일치하지 않습니다.";
+        document.getElementById('error-message').style.display = 'block';
+      }
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/passwordResetSuccess.html
+++ b/src/main/resources/templates/passwordResetSuccess.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>비밀번호 변경 완료</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f7f7f7;
+      margin: 0;
+      padding: 0;
+    }
+    .container {
+      width: 100%;
+      max-width: 400px;
+      margin: 50px auto;
+      background-color: #ffffff;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 20px;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+      text-align: center;
+    }
+    h2 {
+      color: #333;
+    }
+    p {
+      margin: 20px 0;
+      font-size: 16px;
+    }
+    button {
+      display: inline-block;
+      margin-top: 20px;
+      padding: 10px 20px;
+      background-color: #FFD18C;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 16px;
+    }
+    button:hover {
+      background-color: #ffbe58;
+    }
+  </style>
+</head>
+<body>
+
+<div class="container">
+  <h2>비밀번호 변경 완료</h2>
+  <p>비밀번호가 성공적으로 변경되었습니다.</p>
+  <button onclick="window.close()">나가기</button>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### 변경사항
- Thymeleaf 의존성 추가
- 비밀번호 재설정, 재설정 성공 페이지 템플릿 추가
- `PasswordResetController` : 비밀번호 재설정 페이지와 비밀번호 재설정 요청 처리
  - 사용자 비밀번호 재설정 링크 통해 들어왔을 때, `showResetPasswordPage` 메서드 호출되어 Thymeleaf 템플릿을 통해 비밀번호 재설정 페이지를 렌더링 
  - 사용자가 비밀번호를 입력하고 제출하면 `resetPassword` 메서드가 호출

### 테스트

- [ ] 테스트 코드
- [x] API 테스트 